### PR TITLE
Set server to listen on :: so both ipv4 and ipv6 connections can be made

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,7 +19,7 @@ app.get('/api/config', function(req, res){
 });
 
 var httpServer = Http.createServer(app);
-httpServer.listen(config.httpPort);
+httpServer.listen(config.httpPort, "::");
 console.log('listening on port ' + config.httpPort);
 
 var wsConfig = { server: httpServer };


### PR DESCRIPTION
By default, **node.js** only listens on **ipv4**, but it can be configured to listen on both **ipv4** _and_ **ipv6** if you specify `::` as the address.