### PR TITLE
Remove empty channels

### DIFF
--- a/NetfluxWebsocketSrv.js
+++ b/NetfluxWebsocketSrv.js
@@ -69,7 +69,9 @@ dropUser = function (ctx, user) {
                 ctx.timeouts[chanName] = setTimeout(function () {
                     ctx.store.removeChannel(chanName, function (err) {
                         if (err) { console.error("[removeChannelErr]: %s", err); }
-                        console.log("Deleted channel [%s] history from database...", chanName);
+                        else {
+                            console.log("Deleted channel [%s] history from database...", chanName);
+                        }
                     });
                 }, ctx.config.channelRemovalTimeout);
             }

--- a/NetfluxWebsocketSrv.js
+++ b/NetfluxWebsocketSrv.js
@@ -65,15 +65,20 @@ dropUser = function (ctx, user) {
 
             /*  Call removeChannel if it is a function and channel removal is
                 set to true in the config file */
-            if (ctx.config.removeChannels && typeof(ctx.store.removeChannel) === 'function') {
-                ctx.timeouts[chanName] = setTimeout(function () {
-                    ctx.store.removeChannel(chanName, function (err) {
-                        if (err) { console.error("[removeChannelErr]: %s", err); }
-                        else {
-                            console.log("Deleted channel [%s] history from database...", chanName);
-                        }
-                    });
-                }, ctx.config.channelRemovalTimeout);
+            if (ctx.config.removeChannels) {
+                if (typeof(ctx.store.removeChannel) === 'function') {
+                    ctx.timeouts[chanName] = setTimeout(function () {
+                        ctx.store.removeChannel(chanName, function (err) {
+                            if (err) { console.error("[removeChannelErr]: %s", err); }
+                            else {
+                                console.log("Deleted channel [%s] history from database...", chanName);
+                            }
+                        });
+                    }, ctx.config.channelRemovalTimeout);
+                } else {
+                    console.error("You have configured your server to remove empty channels, " +
+                        "however, the database adaptor you are using has not implemented this behaviour.");
+                }
             }
         } else {
             sendChannelMessage(ctx, chan, [user.id, 'LEAVE', chanName, 'Quit: [ dropUser() ]']);

--- a/config.js.dist
+++ b/config.js.dist
@@ -12,6 +12,11 @@ module.exports = {
     // the port used for websockets
     websocketPort: 3000,
 
+    /*  Cryptpad can log activity to stdout
+     *  This may be useful for debugging
+     */
+    logToStdout: false,
+
     // You now have a choice of storage engines
 
     /* amnesiadb only exists in memory.

--- a/config.js.dist
+++ b/config.js.dist
@@ -17,6 +17,15 @@ module.exports = {
      */
     logToStdout: false,
 
+    /*  Cryptpad can be configured to remove channels some number of ms
+        after the last remaining client has disconnected.
+
+        Default behaviour is to keep channels forever.
+        If you enable channel removal, the default removal time is one minute
+    */
+    removeChannels: false,
+    channelRemovalTimeout: 60000,
+
     // You now have a choice of storage engines
 
     /* amnesiadb only exists in memory.

--- a/server.js
+++ b/server.js
@@ -81,6 +81,6 @@ if (config.websocketPort !== config.httpPort) {
 var wsSrv = new WebSocketServer(wsConfig);
 Storage.create(config, function (store) {
     console.log('DB connected');
-    NetfluxSrv.run(store, wsSrv);
+    NetfluxSrv.run(store, wsSrv, config);
     WebRTCSrv.run(wsSrv);
 });

--- a/storage/LogStore.js
+++ b/storage/LogStore.js
@@ -8,11 +8,12 @@ var create = module.exports.create = function(filePath, backingStore) {
 
     var file = Fs.createWriteStream(filePath, {flags: 'a+'});
 
-    return {
-        message: function(channel, msg, callback) {
-            message(file, msg);
-            backingStore.message(channel, msg, callback);
-        },
-        getMessages: backingStore.getMessages
+    var originalMessageFunction = backingStore.message;
+
+    backingStore.message = function(channel, msg, callback) {
+        message(file, msg);
+        originalMessageFunction(channel, msg, callback);
     };
+
+    return backingStore;
 };

--- a/storage/README.md
+++ b/storage/README.md
@@ -42,6 +42,12 @@ This function accepts the name of the channel in which the user is interested, t
 It is only implemented within the leveldb adaptor, making our latest code incompatible with the other back ends.
 While we migrate to our new Netflux API, only the leveldb adaptor will be supported.
 
+## removeChannel(channelName, callback)
+
+This method is called (optionally, see config.js.dist for more info) some amount of time after the last client in a channel disconnects.
+
+It should remove any history of that channel, and execute a callback which takes an error message as an argument.
+
 ## Documenting your adaptor
 
 Naturally, you should comment your code well before making a PR.

--- a/storage/amnesia.js
+++ b/storage/amnesia.js
@@ -19,6 +19,10 @@ module.exports.create = function(conf, cb){
     var db=[],
         index=0;
 
+    if (conf.removeChannels) {
+        console.log("Server is set to remove channels %sms after the last remaining client leaves.", conf.channelRemovalTimeout);
+    }
+
     cb({
         message: function(channelName, content, cb){
             var val = {
@@ -40,6 +44,13 @@ module.exports.create = function(conf, cb){
                 handler(doc.msg);
             });
             if (cb) { cb(); }
+        },
+        removeChannel: function (channelName, cb) {
+            var err = false;
+            db = db.filter(function (msg) {
+                return msg.chan !== channelName;
+            });
+            cb(err);
         },
     });
 };


### PR DESCRIPTION
This probably should have been two different branches, but the bulk of the changes implement (optional) removal of channels some time after the last participant in a channel has disconnected.

The configuration object is now supplied as a third argument to the socket server, and with that in place I also decided to make STDOUT logging configurable (instead of via a constant defined within the server).

Channel removal is configured via two variables:

1. `removeChannels`, which is treated as a boolean (defaulting to 'false')
2. `channelRemovalTimeout`, which must be a number (defaulting to 60000 (one minute))

The only database adaptor which currently implements this behaviour is `amnesiadb` (which only exists in memory anyway).

Databases which do not implement this functionality will continue to work as before no matter how you configure your server.
The server will warn you (at the console) that it meant to remove the channel, but that functionality was not implemented for your chosen adaptor.

If the server is killed (or if it crashes) before these channels are removed, it will not attempt to remove them on rebooting.
I consider this a feature, not a bug.
Sessions should only be cleaned up if the user left the session, not if the session failed.

In our current model we do not differentiate between clients leaving and clients accidentally disconnecting.
While this is possible, the complexity of implementing that is beyond the scope of this PR.
I implemented the timeouts with connectivity issues in mind.
With a sufficiently large window of time (for your definition of sufficient), clients should be able to reconnect and recover their session.

Overall, this small change set addresses a different type of threat model.
Users can collaborate for a time and leave, and their work will vanish.
This makes their session **ephemeral**, not just _zero-knowledge_.