### PR TITLE
Using express.static instead of custom handler

### DIFF
--- a/server.js
+++ b/server.js
@@ -13,12 +13,12 @@ var config = require('./config');
 config.websocketPort = config.websocketPort || config.httpPort;
 
 // support multiple storage back ends
-var Storage = require(config.storage || './storage/mongo');
+var Storage = require(config.storage||'./storage/mongo');
 
 var app = Express();
 app.use(Express.static(__dirname + '/www'));
 
-Fs.exists(__dirname + "/customize", function(e) {
+Fs.exists(__dirname + "/customize", function (e) {
     if (e) { return; }
     console.log("Cryptpad is customizable, see customize.dist/readme.md for details");
 });
@@ -31,7 +31,7 @@ app.use(/^\/[^\/]*$/, Express.static('customize.dist'));
 var httpsOpts;
 if (config.privKeyAndCertFiles) {
     var privKeyAndCerts = '';
-    config.privKeyAndCertFiles.forEach(function(file) {
+    config.privKeyAndCertFiles.forEach(function (file) {
         privKeyAndCerts = privKeyAndCerts + Fs.readFileSync(file);
     });
     var array = privKeyAndCerts.split('\n-----BEGIN ');
@@ -52,30 +52,30 @@ if (config.privKeyAndCertFiles) {
     };
 }
 
-app.get('/api/config', function(req, res) {
+app.get('/api/config', function(req, res){
     var host = req.headers.host.replace(/\:[0-9]+/, '');
     res.setHeader('Content-Type', 'text/javascript');
     res.send('define(' + JSON.stringify({
-        websocketURL: 'ws' + ((httpsOpts) ? 's' : '') + '://' + host + ':' +
+        websocketURL:'ws' + ((httpsOpts) ? 's' : '') + '://' + host + ':' +
             config.websocketPort + '/cryptpad_websocket',
-        webrtcURL: 'ws' + ((httpsOpts) ? 's' : '') + '://' + host + ':' +
+        webrtcURL:'ws' + ((httpsOpts) ? 's' : '') + '://' + host + ':' +
             config.websocketPort + '/cryptpad_webrtc',
     }) + ');');
 });
 
 var httpServer = httpsOpts ? Https.createServer(httpsOpts, app) : Http.createServer(app);
 
-httpServer.listen(config.httpPort, config.httpAddress, function() {
-    console.log('listening on %s', config.httpPort);
+httpServer.listen(config.httpPort,config.httpAddress,function(){
+    console.log('listening on %s',config.httpPort);
 });
 
 var wsConfig = { server: httpServer };
 if (config.websocketPort !== config.httpPort) {
     console.log("setting up a new websocket server");
-    wsConfig = { port: config.websocketPort };
+    wsConfig = { port: config.websocketPort};
 }
 var wsSrv = new WebSocketServer(wsConfig);
-Storage.create(config, function(store) {
+Storage.create(config, function (store) {
     console.log('DB connected');
     NetfluxSrv.run(store, wsSrv, config);
     WebRTCSrv.run(wsSrv);

--- a/server.js
+++ b/server.js
@@ -13,47 +13,25 @@ var config = require('./config');
 config.websocketPort = config.websocketPort || config.httpPort;
 
 // support multiple storage back ends
-var Storage = require(config.storage||'./storage/mongo');
+var Storage = require(config.storage || './storage/mongo');
 
 var app = Express();
 app.use(Express.static(__dirname + '/www'));
 
-Fs.exists(__dirname + "/customize", function (e) {
+Fs.exists(__dirname + "/customize", function(e) {
     if (e) { return; }
     console.log("Cryptpad is customizable, see customize.dist/readme.md for details");
 });
 
-var staticOpts = {
-    index: 'index.html'
-};
-
-var handleFile = function (target, res, fallback, next) {
-    var stream = Fs.createReadStream(target).on('error', function (e) {
-        if (fallback) {
-            handleFile(fallback, res, undefined, next);
-            return;
-        } else {
-            next();
-        }
-    }).on('end', function () {
-        res.end();
-    });
-    stream.pipe(res);
-};
-
 app.use("/customize", Express.static(__dirname + '/customize'));
 app.use("/customize", Express.static(__dirname + '/customize.dist'));
-app.use(/^\/[^\/]*$/, function(req, res, next) {
-    var file = req.originalUrl.slice(1) || 'index.html';
-    handleFile(__dirname + '/customize' + file, // try piping this file first
-        res, __dirname + '/customize.dist/' + file, // if it doesn't exist
-        next); // finally, fall through
-});
+app.use(/^\/[^\/]*$/, Express.static('customize'));
+app.use(/^\/[^\/]*$/, Express.static('customize.dist'));
 
 var httpsOpts;
 if (config.privKeyAndCertFiles) {
     var privKeyAndCerts = '';
-    config.privKeyAndCertFiles.forEach(function (file) {
+    config.privKeyAndCertFiles.forEach(function(file) {
         privKeyAndCerts = privKeyAndCerts + Fs.readFileSync(file);
     });
     var array = privKeyAndCerts.split('\n-----BEGIN ');
@@ -74,30 +52,30 @@ if (config.privKeyAndCertFiles) {
     };
 }
 
-app.get('/api/config', function(req, res){
+app.get('/api/config', function(req, res) {
     var host = req.headers.host.replace(/\:[0-9]+/, '');
     res.setHeader('Content-Type', 'text/javascript');
     res.send('define(' + JSON.stringify({
-        websocketURL:'ws' + ((httpsOpts) ? 's' : '') + '://' + host + ':' +
+        websocketURL: 'ws' + ((httpsOpts) ? 's' : '') + '://' + host + ':' +
             config.websocketPort + '/cryptpad_websocket',
-        webrtcURL:'ws' + ((httpsOpts) ? 's' : '') + '://' + host + ':' +
+        webrtcURL: 'ws' + ((httpsOpts) ? 's' : '') + '://' + host + ':' +
             config.websocketPort + '/cryptpad_webrtc',
     }) + ');');
 });
 
 var httpServer = httpsOpts ? Https.createServer(httpsOpts, app) : Http.createServer(app);
 
-httpServer.listen(config.httpPort,config.httpAddress,function(){
-    console.log('listening on %s',config.httpPort);
+httpServer.listen(config.httpPort, config.httpAddress, function() {
+    console.log('listening on %s', config.httpPort);
 });
 
 var wsConfig = { server: httpServer };
 if (config.websocketPort !== config.httpPort) {
     console.log("setting up a new websocket server");
-    wsConfig = { port: config.websocketPort};
+    wsConfig = { port: config.websocketPort };
 }
 var wsSrv = new WebSocketServer(wsConfig);
-Storage.create(config, function (store) {
+Storage.create(config, function(store) {
     console.log('DB connected');
     NetfluxSrv.run(store, wsSrv, config);
     WebRTCSrv.run(wsSrv);


### PR DESCRIPTION
The original custom file handler code caused the server not sending the content-type header in some cases. This killed the site e.g. when using CloudFlare - safari tried to download the index.html instead of rendering it and chrome displayed the source code.

I might be missing something but I replaced that code with 2 simple express.static handlers - which handle content type (among other things) correctly