### PR TITLE
use replaceState if available

### DIFF
--- a/www/code/main.js
+++ b/www/code/main.js
@@ -495,7 +495,7 @@ define([
                 }
 
                 // set the hash
-                if (!readOnly) { Cryptpad.setHash(editHash); }
+                if (!readOnly) { Cryptpad.replaceHash(editHash); }
 
                 Cryptpad.getPadTitle(function (err, title) {
                     if (err) {

--- a/www/code/main.js
+++ b/www/code/main.js
@@ -495,9 +495,7 @@ define([
                 }
 
                 // set the hash
-                if (!readOnly) {
-                    window.location.hash = editHash;
-                }
+                if (!readOnly) { Cryptpad.setHash(editHash); }
 
                 Cryptpad.getPadTitle(function (err, title) {
                     if (err) {

--- a/www/common/cryptpad-common.js
+++ b/www/common/cryptpad-common.js
@@ -225,6 +225,14 @@ define([
         return secret;
     };
 
+    var setHash = common.setHash = function (hash) {
+        if (!/^#/.test(hash)) { hash = '#' + hash; }
+        if (window.history && window.history.replaceState) {
+            return void window.history.replaceState({}, window.document.title, hash);
+        }
+        window.location.hash = hash;
+    };
+
     var storageKey = common.storageKey = 'CryptPad_RECENTPADS';
 
     /*

--- a/www/common/cryptpad-common.js
+++ b/www/common/cryptpad-common.js
@@ -225,9 +225,9 @@ define([
         return secret;
     };
 
-    var setHash = common.setHash = function (hash) {
-        if (!/^#/.test(hash)) { hash = '#' + hash; }
+    var replaceHash = common.replaceHash = function (hash) {
         if (window.history && window.history.replaceState) {
+            if (!/^#/.test(hash)) { hash = '#' + hash; }
             return void window.history.replaceState({}, window.document.title, hash);
         }
         window.location.hash = hash;

--- a/www/pad/main.js
+++ b/www/pad/main.js
@@ -601,9 +601,7 @@ define([
                 }
 
                 // set the hash
-                if (!readOnly) {
-                    window.location.hash = editHash;
-                }
+                if (!readOnly) { Cryptpad.setHash(editHash); }
 
                 Cryptpad.getPadTitle(function (err, title) {
                     if (err) {

--- a/www/pad/main.js
+++ b/www/pad/main.js
@@ -601,7 +601,7 @@ define([
                 }
 
                 // set the hash
-                if (!readOnly) { Cryptpad.setHash(editHash); }
+                if (!readOnly) { Cryptpad.replaceHash(editHash); }
 
                 Cryptpad.getPadTitle(function (err, title) {
                     if (err) {

--- a/www/poll/main.js
+++ b/www/poll/main.js
@@ -914,9 +914,7 @@ define([
                 editHash = Cryptpad.getEditHashFromKeys(info.channel, secret.keys);
             }
             // set the hash
-            if (!readOnly) {
-                window.location.hash = editHash;
-            }
+            if (!readOnly) { Cryptpad.setHash(editHash); }
 
             module.patchText = TextPatcher.create({
                 realtime: realtime,

--- a/www/poll/main.js
+++ b/www/poll/main.js
@@ -914,7 +914,7 @@ define([
                 editHash = Cryptpad.getEditHashFromKeys(info.channel, secret.keys);
             }
             // set the hash
-            if (!readOnly) { Cryptpad.setHash(editHash); }
+            if (!readOnly) { Cryptpad.replaceHash(editHash); }
 
             module.patchText = TextPatcher.create({
                 realtime: realtime,

--- a/www/slide/main.js
+++ b/www/slide/main.js
@@ -585,7 +585,7 @@ define([
 
                 // set the hash
                 if (!window.location.hash || window.location.hash === '#') {
-                    Cryptpad.setHash(editHash);
+                    Cryptpad.replaceHash(editHash);
                 }
 
                 Cryptpad.getPadTitle(function (err, title) {

--- a/www/slide/main.js
+++ b/www/slide/main.js
@@ -585,7 +585,7 @@ define([
 
                 // set the hash
                 if (!window.location.hash || window.location.hash === '#') {
-                    window.location.hash = editHash;
+                    Cryptpad.setHash(editHash);
                 }
 
                 Cryptpad.getPadTitle(function (err, title) {


### PR DESCRIPTION
Currently, if users hit the back button while on newly created pad, they will navigate to `/pad/` instead of the home page, so they have to hit 'back' a second time.

This change makes changes to the hash _not_ occupy an additional place in the history, which is a little more intuitive.