### PR TITLE
UI improvements for mobile browsers

### DIFF
--- a/www/pad/index.html
+++ b/www/pad/index.html
@@ -3,6 +3,7 @@
 <head>
     <title>CryptPad</title>
     <meta content="text/html; charset=utf-8" http-equiv="content-type"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" type="image/png"
         href="/customize/main-favicon.png"
         data-main-favicon="/customize/main-favicon.png"

--- a/www/pad/inner.html
+++ b/www/pad/inner.html
@@ -7,6 +7,9 @@
     <script src="/bower_components/jquery/dist/jquery.min.js"></script>
     <script src="/bower_components/ckeditor/ckeditor.js"></script>
     <style>
+    html, body {
+        margin: 0px;
+    }
     #cke_1_top {
         overflow: visible;
     }

--- a/www/pad/inner.html
+++ b/www/pad/inner.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta content="text/html; charset=utf-8" http-equiv="content-type"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/bower_components/components-font-awesome/css/font-awesome.min.css">
     <script src="/bower_components/jquery/dist/jquery.min.js"></script>
     <script src="/bower_components/ckeditor/ckeditor.js"></script>

--- a/www/pad/inner.html
+++ b/www/pad/inner.html
@@ -2,7 +2,6 @@
 <html>
 <head>
     <meta content="text/html; charset=utf-8" http-equiv="content-type"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="/bower_components/components-font-awesome/css/font-awesome.min.css">
     <script src="/bower_components/jquery/dist/jquery.min.js"></script>
     <script src="/bower_components/ckeditor/ckeditor.js"></script>

--- a/www/pad/main.js
+++ b/www/pad/main.js
@@ -763,9 +763,13 @@ define([
 
     var first = function () {
         Ckeditor = ifrw.CKEDITOR;
-
         if (Ckeditor) {
             //andThen(Ckeditor);
+            // mobile configuration
+            Ckeditor.config.toolbarCanCollapse = true;
+            if (screen.height < 800) {
+              Ckeditor.config.toolbarStartupExpanded = false;
+            }
             second(Ckeditor);
         } else {
             console.log("Ckeditor was not defined. Trying again in %sms",interval);

--- a/www/pad/main.js
+++ b/www/pad/main.js
@@ -770,6 +770,9 @@ define([
             Ckeditor.config.height = '72vh';
             if (screen.height < 800) {
               Ckeditor.config.toolbarStartupExpanded = false;
+              $('meta[name=viewport]').attr('content', 'width=device-width, initial-scale=1.0, user-scalable=no');
+            } else {
+              $('meta[name=viewport]').attr('content', 'width=device-width, initial-scale=1.0, user-scalable=yes');
             }
             second(Ckeditor);
         } else {

--- a/www/pad/main.js
+++ b/www/pad/main.js
@@ -767,6 +767,7 @@ define([
             //andThen(Ckeditor);
             // mobile configuration
             Ckeditor.config.toolbarCanCollapse = true;
+            Ckeditor.config.height = '72vh';
             if (screen.height < 800) {
               Ckeditor.config.toolbarStartupExpanded = false;
             }


### PR DESCRIPTION
Features:
- Get rid of margins on mobile
- Disable autozoom on mobile
- Enable toolbar toggling, set to collapsed by default for small screens
- Add a height setting to fix bad 200px default size on mobile (it seems to only affect mobile browsers)

Side effects:
- Disabling autozoom unfortunately disables all zooming on mobile
- Custom height setting is undone by toggling toolbar twice

I think this improves the mobile situation considerably (in a stopgap way until CKEditor 5, which should have real mobile support).