### PR TITLE
Some CSS fixes

### DIFF
--- a/customize.dist/src/less/toolbar.less
+++ b/customize.dist/src/less/toolbar.less
@@ -95,6 +95,7 @@
     }
 
     button {
+        color: #000;
         background-color: inherit;
         background-image: linear-gradient(to bottom,#fff,#e4e4e4);
         border: 1px solid #A6A6A6;

--- a/customize.dist/src/less/toolbar.less
+++ b/customize.dist/src/less/toolbar.less
@@ -253,13 +253,12 @@
         input {
             font-size: 1.5em;
             vertical-align: middle;
-            height: 100%;
             box-sizing: border-box;
             border: 1px solid black;
             background: #fff;
             cursor: auto;
             width: 300px;
-            padding: 0px 5px;
+            padding: 5px 5px;
         }
     }
     .cryptpad-link {

--- a/customize.dist/toolbar.css
+++ b/customize.dist/toolbar.css
@@ -164,6 +164,7 @@
   margin-right: 2px;
 }
 .cryptpad-toolbar button {
+  color: #000;
   background-color: inherit;
   background-image: linear-gradient(to bottom, #fff, #e4e4e4);
   border: 1px solid #A6A6A6;

--- a/customize.dist/toolbar.css
+++ b/customize.dist/toolbar.css
@@ -324,13 +324,12 @@
 .cryptpad-toolbar-top .cryptpad-title input {
   font-size: 1.5em;
   vertical-align: middle;
-  height: 100%;
   box-sizing: border-box;
   border: 1px solid black;
   background: #fff;
   cursor: auto;
   width: 300px;
-  padding: 0px 5px;
+  padding: 5px 5px;
 }
 .cryptpad-toolbar-top .cryptpad-link {
   position: absolute;

--- a/www/drive/file.css
+++ b/www/drive/file.css
@@ -66,6 +66,7 @@ li {
 .contextMenu {
   display: none;
   position: absolute;
+  z-index: 50;
 }
 .contextMenu li {
   padding: 0;
@@ -247,6 +248,7 @@ span.fa-folder-open {
 }
 #content div.grid li input {
   width: 100%;
+  margin-top: 5px;
 }
 #content div.grid li .fa {
   display: block;

--- a/www/drive/file.less
+++ b/www/drive/file.less
@@ -95,6 +95,7 @@ li {
 .contextMenu {
     display: none;
     position: absolute;
+    z-index: 50;
     li {
         padding: 0;
         font-size: 16px;
@@ -292,6 +293,7 @@ span {
             }
             input {
                 width: 100%;
+                margin-top: 5px;
             }
             .fa {
                 display: block;

--- a/www/drive/main.js
+++ b/www/drive/main.js
@@ -1424,7 +1424,8 @@ define([
                     // Open the menu
                     $iframe.find('.contextMenu').css({
                         top: ($context.offset().top + 32) + 'px',
-                        right: '0px'
+                        right: '0px',
+                        left: ''
                     });
                     $li.contextmenu();
                 });

--- a/www/poll/index.html
+++ b/www/poll/index.html
@@ -92,6 +92,7 @@
             margin: auto;
 
             min-width: 80%;
+            width: 80%;
             min-height: 5em;
             font-size: 20px;
             font-weight: bold;


### PR DESCRIPTION
Some CSS fixes:

- Fixed textarea in poll being too large causing overflow
- Fix title input in pads being too large when on mobile/zoomed in
- Toolbar buttons are now always the intended color (even when you have a custom theme)
- Fixed the context-menu not appearing at the right place when using the dropdown arrow (mobile/zoomed in)