### PR TITLE
Adding a warning and header to delete/reset docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -70,9 +70,12 @@ bower update;
 # serverside dependencies
 npm update;
 ```
+## Deleting all data and resetting Cryptpad
+
 
 To reset your instance of Cryptpad and remove all the data that is being stored:
 
+**WARNING: This will reset your Cryptpad instance and remove all data**
 ```
 # change into your cryptpad directory
 cd /your/cryptpad/instance/location;


### PR DESCRIPTION
The delete/reset instructions were directly after the upgrade instructions. Figured its useful to put a header and a warning to prevent running those commands by mistake when upgrading.