### PR TITLE
Reenable X-Frame-Options: SAMEORIGIN

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -18,7 +18,7 @@ module.exports = {
     httpHeaders: {
         "X-XSS-Protection": "1; mode=block",
         "X-Content-Type-Options": "nosniff",
-        // 'X-Frame-Options': 'SAMEORIGIN',
+        'X-Frame-Options': 'SAMEORIGIN',
     },
 
     contentSecurity: [


### PR DESCRIPTION
This header seems to have been commented out without a reason.
Setting X-Frame-Options to SAMEORIGIN works fine. (Tested in Chromium 59/60/61, Firefox 52/53, Safari 10.1.1)