### PR TITLE
Issue #151: Spacing between "Log-in" and "Register" buttons

### DIFF
--- a/customize.dist/pages.js
+++ b/customize.dist/pages.js
@@ -162,7 +162,7 @@ define([
                 ])
             ]),
             h('button.btn.btn-secondary.login.half.first', Msg.login_login),
-            h('button.btn.btn-success.register.half.first', Msg.login_register),
+            h('button.btn.btn-success.register.half', Msg.login_register),
             h('p.separator', Msg.login_orNoLogin),
             h('p#buttons.buttons'),
             h('p.driveLink', [
@@ -363,7 +363,7 @@ define([
                         h('button.btn.btn-primary.login.first', Msg.login_login),
                         h('div.extra', [
                             h('p', Msg.login_notRegistered),
-                            h('button#register.btn.btn-success.register.first', Msg.login_register)
+                            h('button#register.btn.btn-success.register', Msg.login_register)
                         ])
                     ])
                 ])

--- a/customize.dist/src/less/cryptpad.less
+++ b/customize.dist/src/less/cryptpad.less
@@ -428,7 +428,7 @@ noscript {
             width: 100%;
             cursor: pointer;
             &.half {
-                width: ~"calc(50% - 2px)";
+                width: ~"calc(50% - 10px)";
                 &:not(.first) {
                     float: right;
                 }


### PR DESCRIPTION
- Removed ".first" class from Register button
- Increase spacing between buttons