### PR TITLE
Translated missing out.presentSuccess to german

### DIFF
--- a/customize.dist/translations/messages.de.js
+++ b/customize.dist/translations/messages.de.js
@@ -53,7 +53,7 @@
       out.shareSuccess = 'URL wurde in die Zwischenablage kopiert';
 
       out.presentButtonTitle = "Präsentationsmodus starten";
-      out.presentSuccess = 'Hit ESC to exit presentation mode';
+      out.presentSuccess = 'Drücke ESC um den Präsentationsmodus zu verlassen!';
 
       out.backgroundButtonTitle = 'Die Hintergrundfarbe der Präsentation ändern';
       out.colorButtonTitle = 'Die Textfarbe im Präsentationsmodus ändern';


### PR DESCRIPTION
out.presentSuccess wasn't translated to german yet, added german translation. (I'm a native speaker of german.)