### PR TITLE
Properly escape sed match/replace expressions

### DIFF
--- a/container-start.sh
+++ b/container-start.sh
@@ -9,15 +9,20 @@ mkdir -p customize
 # Linking config.js
 [ ! -h config.js ] && echo "Linking config.js" && ln -s customize/config.js config.js
 
+# Thanks to http://stackoverflow.com/a/10467453
+sedeasy() {
+  sed -i "s/$1/$(echo $2 | sed -e 's/[\/&]/\\&/g')/g" $3
+}
+
 # Configure
 [ -n "$USE_SSL" ] && echo "Using secure websockets: $USE_SSL" \
-  && sed -i "s/useSecureWebsockets: .*/useSecureWebsockets: ${USE_SSL},/g" customize/config.js
+  && sedeasy "useSecureWebsockets: [^,]*," "useSecureWebsockets: ${USE_SSL}," customize/config.js
 
 [ -n "$STORAGE" ] && echo "Using storage adapter: $STORAGE" \
-  && sed -i "s/storage: .*/storage: ${STORAGE},/g" customize/config.js
+  && sedeasy "storage: [^,]*," "storage: ${STORAGE}," customize/config.js
 
 [ -n "$LOG_TO_STDOUT" ] && echo "Logging to stdout: $LOG_TO_STDOUT" \
-  && sed -i "s/logToStdout: .*/logToStdout: ${LOG_TO_STDOUT},/g" customize/config.js
+  && sedeasy "logToStdout: [^,]*," "logToStdout: ${LOG_TO_STDOUT}," customize/config.js
 
 
 exec node ./server.js

--- a/docs/cryptpad-docker.md
+++ b/docs/cryptpad-docker.md
@@ -22,15 +22,6 @@ Or, using docker-compose
 docker-compose up -d
 ```
 
-## TODO
-
-```
-cryptpad_1  | Linking config.js
-cryptpad_1  | Using secure websockets: true
-cryptpad_1  | Using storage adapter: './storage/file'
-cryptpad_1  | sed: -e expression #1, char 27: unknown option to `s'
-```
-
 ## Configuration
 
 Set configurations Dockerfile or in .env (using docker-compose) file.


### PR DESCRIPTION
This fixes an error during container startup due to interpolating a
$STORAGE value that may contain slashes or other "active" characters:

    ...
    Using secure websockets: false
    Using storage adapter: ./storage/file
    sed: bad option in substitution expression

I guess this is the same as the TODO item mentioned in the
docs/cryptpad-docker page.


Also add a trailing ',' in the search expression to avoid substituting
in the comment above the actual definition:

    /*  If Cryptpad is proxied without using https, the server needs to know.
     *  Specify 'useSecureWebsockets: true' so that it can send
    ...

By the way, I have a related question: I'm using cryptpad behind an nginx reverse proxy (SSL). Should I specify `useSecureWebsockets: true` or false? I'm a bit confused by the wording.

Best, Thomas