### PR TITLE
Remove useSecureWebsockets variable, further simplify docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,4 @@ EXPOSE 3000
 VOLUME /cryptpad/datastore
 VOLUME /cryptpad/customize
 
-ENV STORAGE='./storage/file'
-ENV LOG_TO_STDOUT=true
-
 CMD ["/sbin/tini", "--", "/cryptpad/container-start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ EXPOSE 3000
 VOLUME /cryptpad/datastore
 VOLUME /cryptpad/customize
 
-ENV USE_SSL=false
 ENV STORAGE='./storage/file'
 ENV LOG_TO_STDOUT=true
 

--- a/config.example.js
+++ b/config.example.js
@@ -93,12 +93,6 @@ module.exports = {
      */
     //useExternalWebsocket: false,
 
-    /*  If CryptPad is proxied without using https, the server needs to know.
-     *  Specify 'useSecureWebsockets: true' so that it can send
-     *  Content Security Policy Headers that prevent http and https from mixing
-     */
-     useSecureWebsockets: false,
-
     /*  CryptPad can log activity to stdout
      *  This may be useful for debugging
      */

--- a/config.example.js
+++ b/config.example.js
@@ -96,7 +96,7 @@ module.exports = {
     /*  CryptPad can log activity to stdout
      *  This may be useful for debugging
      */
-    logToStdout: false,
+    logToStdout: true,
 
     /*  CryptPad supports verbose logging
      *  (false by default)

--- a/config.example.js
+++ b/config.example.js
@@ -83,7 +83,9 @@ module.exports = {
     websocketPath: '/cryptpad_websocket',
 
     /*  it is assumed that your websocket will bind to the same port as http
-     *  you can override this behaviour by supplying a number via websocketPort
+     *  you can override this behaviour by supplying a number via websocketPort.
+     *  If this differs from httpPort, you have to specify a full absolute
+     *  websocketPath as well!
      */
     //websocketPort: 3000,
 

--- a/container-start.sh
+++ b/container-start.sh
@@ -15,9 +15,6 @@ sedeasy() {
 }
 
 # Configure
-[ -n "$USE_SSL" ] && echo "Using secure websockets: $USE_SSL" \
-  && sedeasy "useSecureWebsockets: [^,]*," "useSecureWebsockets: ${USE_SSL}," customize/config.js
-
 [ -n "$STORAGE" ] && echo "Using storage adapter: $STORAGE" \
   && sedeasy "storage: [^,]*," "storage: ${STORAGE}," customize/config.js
 

--- a/container-start.sh
+++ b/container-start.sh
@@ -9,17 +9,4 @@ mkdir -p customize
 # Linking config.js
 [ ! -h config.js ] && echo "Linking config.js" && ln -s customize/config.js config.js
 
-# Thanks to http://stackoverflow.com/a/10467453
-sedeasy() {
-  sed -i "s/$1/$(echo $2 | sed -e 's/[\/&]/\\&/g')/g" $3
-}
-
-# Configure
-[ -n "$STORAGE" ] && echo "Using storage adapter: $STORAGE" \
-  && sedeasy "storage: [^,]*," "storage: ${STORAGE}," customize/config.js
-
-[ -n "$LOG_TO_STDOUT" ] && echo "Logging to stdout: $LOG_TO_STDOUT" \
-  && sedeasy "logToStdout: [^,]*," "logToStdout: ${LOG_TO_STDOUT}," customize/config.js
-
-
 exec node ./server.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       - traefik.port=3000
       - traefik.frontend.passHostHeader=true
     environment:
-      - USE_SSL=${USE_SSL}
       - STORAGE=${STORAGE}
       - LOG_TO_STDOUT=${LOG_TO_STDOUT}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,7 @@ version: '2'
 services:
 
   cryptpad:
-    build:
-      context: .
-      args:
-        - VERSION=${VERSION}
+    build: .
     image: "xwiki/cryptpad:${VERSION}"
     hostname: cryptpad
 

--- a/docs/cryptpad-docker.md
+++ b/docs/cryptpad-docker.md
@@ -1,10 +1,10 @@
 # Cryptpad Docker Image
 
 - Ready for use with traffic
-- Using github master for now, release 0.3.0 too old
+- Built from current working directory
 - Creating customize folder
 - Adding config.js to customize folder
-- Persistance for datastore and customize folder
+- Persistence for datastore and customize folder
 
 ## Run
 
@@ -21,12 +21,12 @@ Or, using docker-compose
 docker-compose up -d
 ```
 
-## Persistance
+## Persistence
 
 The docker-compose file is preconfigured to persist folders
 
-- cryptpad/datastore --> ./data/customize
-- cryptpad/customize --> ./data/customize
+- /cryptpad/datastore --> ./data/files
+- /cryptpad/customize --> ./data/customize
 
 In customize included find your configuration in `config.js`.
 

--- a/docs/cryptpad-docker.md
+++ b/docs/cryptpad-docker.md
@@ -27,7 +27,6 @@ docker-compose up -d
 Set configurations Dockerfile or in .env (using docker-compose) file.
 
 - VERSION=latest
-- USE_SSL=false
 - STORAGE='./storage/file'
 - LOG_TO_STDOUT=true
 

--- a/docs/cryptpad-docker.md
+++ b/docs/cryptpad-docker.md
@@ -1,6 +1,5 @@
 # Cryptpad Docker Image
 
-- Configuration via .env file
 - Ready for use with traffic
 - Using github master for now, release 0.3.0 too old
 - Creating customize folder
@@ -21,18 +20,6 @@ Or, using docker-compose
 ```
 docker-compose up -d
 ```
-
-## Configuration
-
-Set configurations Dockerfile or in .env (using docker-compose) file.
-
-- VERSION=latest
-- STORAGE='./storage/file'
-- LOG_TO_STDOUT=true
-
-The .env variables are read by docker-compose and forwarded to docker container.
-On runtime, in `bin/container-start.sh` the settings are written to the `config.js` file.
-
 
 ## Persistance
 

--- a/server.js
+++ b/server.js
@@ -12,7 +12,6 @@ var Path = require("path");
 
 var config = require('./config');
 var websocketPort = config.websocketPort || config.httpPort;
-var useSecureWebsockets = config.useSecureWebsockets || false;
 
 // support multiple storage back ends
 var Storage = require(config.storage||'./storage/file');
@@ -132,9 +131,7 @@ app.get('/api/config', function(req, res){
         removeDonateButton: (config.removeDonateButton === true),
         allowSubscriptions: (config.allowSubscriptions === true),
 
-        websocketPath: config.useExternalWebsocket ? undefined : config.websocketPath,
-        websocketURL:'ws' + ((useSecureWebsockets) ? 's' : '') + '://' + host + ':' +
-            websocketPort + '/cryptpad_websocket',
+        websocketPath: config.websocketPath,
     }) + ');');
 });
 

--- a/www/common/cryptpad-common.js
+++ b/www/common/cryptpad-common.js
@@ -275,7 +275,6 @@ define([
     };
 
     common.getWebsocketURL = function () {
-        if (!Config.websocketPath) { return Config.websocketURL; }
         var path = Config.websocketPath;
         if (/^ws{1,2}:\/\//.test(path)) { return path; }
 


### PR DESCRIPTION
following discussion in #166.

I found the useSecureWebsockets variable rather confusing, and as far as I can see also not useful anymore in the current implementation. Removing it and some of the other env vars help it KISS.