### PR TITLE
Use CryptPad everywhere instead of Cryptpad in titles

### DIFF
--- a/www/invite/index.html
+++ b/www/invite/index.html
@@ -2,7 +2,7 @@
 <html class="cp">
 <!-- If this file is not called customize.dist/src/template.html, it is generated -->
 <head>
-    <title data-localization="main_title">Cryptpad: Zero Knowledge, Collaborative Real Time Editing</title>
+    <title data-localization="main_title">CryptPad: Zero Knowledge, Collaborative Real Time Editing</title>
     <meta content="text/html; charset=utf-8" http-equiv="content-type"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <link rel="icon" type="image/png" href="/customize/main-favicon.png" id="favicon"/>

--- a/www/profile/index.html
+++ b/www/profile/index.html
@@ -2,7 +2,7 @@
 <html class="cp">
 <!-- If this file is not called customize.dist/src/template.html, it is generated -->
 <head>
-    <title data-localization="main_title">Cryptpad: Zero Knowledge, Collaborative Real Time Editing</title>
+    <title data-localization="main_title">CryptPad: Zero Knowledge, Collaborative Real Time Editing</title>
     <meta content="text/html; charset=utf-8" http-equiv="content-type"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <link rel="icon" type="image/png" href="/customize/main-favicon.png" id="favicon"/>


### PR DESCRIPTION
Noticed there were some residual "Cryptpad" titles, so I changed the casing on those, as it would flash briefly in the title bar 📸 