### PR TITLE
Fix docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 data
 Dockerfile
 docker-compose.yml
+.dockerignore
 .git
 .gitignore
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ node_js:
 script:
   - npm run-script lint
   - npm run-script flow
+  - docker build -t xwiki/cryptpad .

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . /cryptpad
 WORKDIR /cryptpad
 
 RUN apk add --no-cache git tini \
-   && npm install \
+   && npm install --production \
    && npm install -g bower \
    && bower install --allow-root
 


### PR DESCRIPTION
This fixes the `Failed at the heapdump@0.3.9 install script 'node-gyp rebuild'.` issue so docker builds again.