### PR TITLE
Fixed customization of main pages

### DIFF
--- a/server.js
+++ b/server.js
@@ -117,6 +117,7 @@ Fs.exists(__dirname + "/customize", function (e) {
 
 var mainPages = config.mainPages || ['index', 'privacy', 'terms', 'about', 'contact'];
 var mainPagePattern = new RegExp('^\/(' + mainPages.join('|') + ').html$');
+app.get(mainPagePattern, Express.static(__dirname + '/customize'));
 app.get(mainPagePattern, Express.static(__dirname + '/customize.dist'));
 
 app.use("/blob", Express.static(Path.join(__dirname, (config.blobPath || './blob')), {


### PR DESCRIPTION
It appears that even though terms.html, index.html etc ("main pages") are in the customize.dist folder, we could not customize these pages by creating a similarly-named file in the customize folder.

Adding this line reuses the same mecanism as lines 127-128 to recover this behavior on main pages.