### PR TITLE
add a logout page

### DIFF
--- a/www/logout/index.html
+++ b/www/logout/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html class="cp">
+<!-- If this file is not called customize.dist/src/template.html, it is generated -->
+<head>
+    <title data-localization="main_title">CryptPad: Zero Knowledge, Collaborative Real Time Editing</title>
+    <meta content="text/html; charset=utf-8" http-equiv="content-type"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <script async data-main="main" src="/bower_components/requirejs/require.js"></script>
+    <link rel="icon" type="image/png" href="/customize/main-favicon.png" id="favicon"/>
+</head>
+<body class="html">
+    <noscript>
+        <p><strong>OOPS</strong> In order to do encryption in your browser, Javascript is really <strong>really</strong> required.</p>
+        <p><strong>OUPS</strong> Afin de pouvoir réaliser le chiffrement dans votre navigateur, Javascript est <strong>vraiment</strong> nécessaire.</p>
+    </noscript>
+</html>

--- a/www/logout/main.js
+++ b/www/logout/main.js
@@ -1,0 +1,5 @@
+define(['/bower_components/localforage/dist/localforage.min.js'], function (localForage) {
+    localForage.clear();
+    sessionStorage.clear();
+    localStorage.clear();
+});


### PR DESCRIPTION
This PR adds a /logout URL that allows destroying user session (local storage, session storage & indexedDB) with a minimum number of loaded dependencies.

This is useful for SSO systems that need to log users out of any protected application by loading a logout URL