### PR TITLE
Add check for secret object to fix undefined error

### DIFF
--- a/www/common/sframe-common-outer.js
+++ b/www/common/sframe-common-outer.js
@@ -215,8 +215,8 @@ define([
                 }));
             }
         }).nThen(function () {
+            var parsed = Utils.Hash.parsePadUrl(window.location.href);
             if (!secret) {
-                var parsed = Utils.Hash.parsePadUrl(window.location.href);
                 secret = Utils.Hash.getSecrets(parsed.type, void 0, password);
             }
             var readOnly = secret.keys && !secret.keys.editKeyStr;
@@ -226,7 +226,6 @@ define([
                 secret.keys = secret.key;
                 readOnly = false;
             }
-            var parsed = Utils.Hash.parsePadUrl(window.location.href);
             if (!parsed.type) { throw new Error(); }
             var defaultTitle = Utils.Hash.getDefaultName(parsed);
             var edPublic;

--- a/www/common/sframe-common-outer.js
+++ b/www/common/sframe-common-outer.js
@@ -215,6 +215,10 @@ define([
                 }));
             }
         }).nThen(function () {
+            if (!secret) {
+                var parsed = Utils.Hash.parsePadUrl(window.location.href);
+                secret = Utils.Hash.getSecrets(parsed.type, void 0, password);
+            }
             var readOnly = secret.keys && !secret.keys.editKeyStr;
             var isNewHash = true;
             if (!secret.keys) {


### PR DESCRIPTION
Currently, when a user uploads a file and chooses to also password protect the file, they will receive the following error when subsequently trying to load the file from their own drive:

```
ncaught TypeError: Cannot read property 'keys' of undefined
    at sframe-common-outer.js?ver=2.4.0-ws3:218
    at index.js?ver=2.4.0-ws3:25
    at cryptpad-common.js?ver=2.4.0-ws3:313
    at cryptpad-common.js?ver=2.4.0-ws3:1049
    at Object.queries.(/file/anonymous function) (https://cryptpad.fr/common/outer/worker-channel.js?ver=2.4.0-ws3:44:17)
    at worker-channel.js?ver=2.4.0-ws3:129
    at common-util.js?ver=2.4.0-ws3:23
    at Array.forEach (<anonymous>)
    at Object.fire (common-util.js?ver=2.4.0-ws3:23)
    at MessagePort.worker.port.onmessage (cryptpad-common.js?ver=2.4.0-ws3:949)
```

which seems to be happening because this code block referenced above:

```
        }).nThen(function () {
            var readOnly = secret.keys && !secret.keys.editKeyStr;
            var isNewHash = true;
```

is executed before this one (137-140):

```
                var todo = function () {
                    secret = Utils.Hash.getSecrets(parsed.type, void 0, password);
                    Cryptpad.getShareHashes(secret, waitFor(function (err, h) { hashes = h; }));
                };
```

I'm not a JS expert but my proposed change, which simply checks if secret is defined / assigned and sets it if not, fixed it for my own instance. If this is actually intended behavior or if there is a better fix to this, a pull deny and an explanation would be super appreciated.

Thanks.