### PR TITLE
Update docker start script to bust the cache on each run

### DIFF
--- a/container-start.sh
+++ b/container-start.sh
@@ -24,5 +24,5 @@ sedeasy() {
 [ -n "$LOG_TO_STDOUT" ] && echo "Logging to stdout: $LOG_TO_STDOUT" \
   && sedeasy "logToStdout: [^,]*," "logToStdout: ${LOG_TO_STDOUT}," customize/config.js
 
-
+export FRESH=1
 exec node ./server.js


### PR DESCRIPTION
Update docker run script to bust the cache on each run. This is to ensure there aren't left over cache items when a container is started with a new version or the config has been changed heavily.