### PR TITLE
Add Dockerfile for arm64 support

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -13,13 +13,13 @@ RUN apt install -y git \
    && npm install -g bower \
    && bower install --allow-root
 
-EXPOSE 3000
+EXPOSE 3000 3001
 
 VOLUME /cryptpad/datastore
 VOLUME /cryptpad/customize
 
 ENV USE_SSL=false
-ENV STORAGE='./storage/file'
+ENV STORAGE=\'./storage/file\'
 ENV LOG_TO_STDOUT=true
 
 CMD ["/sbin/tini", "--", "/cryptpad/container-start.sh"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,25 @@
+FROM arm64v8/node:6
+
+COPY . /cryptpad
+WORKDIR /cryptpad
+
+RUN npm config set unsafe-perm true
+
+ADD https://github.com/krallin/tini/releases/download/v0.18.0/tini-static-arm64 /sbin/tini
+RUN chmod a+x /sbin/tini
+
+RUN apt install -y git \
+   && npm install --production \
+   && npm install -g bower \
+   && bower install --allow-root
+
+EXPOSE 3000
+
+VOLUME /cryptpad/datastore
+VOLUME /cryptpad/customize
+
+ENV USE_SSL=false
+ENV STORAGE='./storage/file'
+ENV LOG_TO_STDOUT=true
+
+CMD ["/sbin/tini", "--", "/cryptpad/container-start.sh"]


### PR DESCRIPTION
Cryptpad will run on arm64 but needs a totally different base image and some other Dockerfile tweaks. This PR adds a Dockerfile.arm64 that can be used to deploy on arm64 boards/VPS instances like the Raspberry Pi or the Scaleway arm64v8 offerings.