### PR TITLE
Minor Dockerfile updates/fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ RUN apk add --no-cache git tini \
    && npm install -g bower \
    && bower install --allow-root
 
-EXPOSE 3000
+EXPOSE 3000 3001
 
 VOLUME /cryptpad/datastore
 VOLUME /cryptpad/customize
 
 ENV USE_SSL=false
-ENV STORAGE='./storage/file'
+ENV STORAGE=\'./storage/file\'
 ENV LOG_TO_STDOUT=true
 
 CMD ["/sbin/tini", "--", "/cryptpad/container-start.sh"]


### PR DESCRIPTION
Add port 3001 to the exposed ports list (used by the http safe port in the standard config)

FIX the STORAGE var so it doesn't cause a subtle error when the config.js file is parsed at runtime. This fixes the storage limits from being applied to users and also allows the api/config file to properly pickup a number of config changes that aren't picked up in the previous form of the Dockerfile