### PR TITLE
Issue #198: Add printing option to /code

### DIFF
--- a/customize.dist/src/less2/include/app-print.less
+++ b/customize.dist/src/less2/include/app-print.less
@@ -46,6 +46,38 @@
                     display: block;
                 }
             }
+            // Code app
+            body.cp-app-code {
+                display: block;
+                * {
+                    visibility: hidden;
+                    height: auto;
+                    max-height: none;
+                }
+                #cme_toolbox {
+                    display: none;
+                }
+                #cp-app-code-editor {
+                    display: block;
+                    #cp-app-code-container {
+                        display: none;
+                    }
+                    #cp-app-code-preview {
+                        display: block;
+                        #cp-app-code-print {
+                            display: block;
+                            overflow: visible !important;
+                            width: 100%;
+                            visibility: visible;
+                            * { visibility: visible; }
+                            pre { border: none; }
+                        }
+                        #cp-app-code-preview-content {
+                            display: none !important;
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/www/code/app-code.less
+++ b/www/code/app-code.less
@@ -124,5 +124,17 @@
             display: none !important;
         }
     }
+    @media print {
+        #cp-app-code-container {
+            display: none;
+        }
+    }
+    #cp-app-code-print {
+        position: relative;
+        display: none;
+        margin: 1em auto;
+        .markdown_preformatted-code;
+        .markdown_gfm-table(black);
+    }
 }
 

--- a/www/code/app-code.less
+++ b/www/code/app-code.less
@@ -124,11 +124,6 @@
             display: none !important;
         }
     }
-    @media print {
-        #cp-app-code-container {
-            display: none;
-        }
-    }
     #cp-app-code-print {
         position: relative;
         display: none;

--- a/www/code/inner.html
+++ b/www/code/inner.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="cp-app-noscroll">
+<html class="cp-app-noscroll cp-app-print">
 <head>
     <meta content="text/html; charset=utf-8" http-equiv="content-type"/>
     <script async data-bootload="/code/inner.js" data-main="/common/sframe-boot.js?ver=1.6" src="/bower_components/requirejs/require.js?ver=2.3.5"></script>
@@ -17,6 +17,7 @@
     </div>
     <div id="cp-app-code-preview">
         <div id="cp-app-code-preview-content"></div>
+        <div id="cp-app-code-print"></div>
     </div>
   </div>
 </body>

--- a/www/code/inner.js
+++ b/www/code/inner.js
@@ -70,6 +70,16 @@ define([
         'xml',
     ]);
 
+    var mkPrintButton = function (framework, $content, $print) {
+        var $printButton = framework._.sfCommon.createButton('print', true);
+        $printButton.click(function () {
+            $print.html($content.html());
+            window.focus();
+            window.print();
+            framework.feedback('PRINT_CODE');
+        });
+        framework._.toolbar.$drawer.append($printButton);
+    };
     var mkMarkdownTb = function (editor, framework) {
         var $codeMirrorContainer = $('#cp-app-code-container');
         var markdownTb = framework._.sfCommon.createMarkdownToolbar(editor);
@@ -265,6 +275,11 @@ define([
 
         var previewPane = mkPreviewPane(editor, CodeMirror, framework, isPresentMode);
         var markdownTb = mkMarkdownTb(editor, framework);
+
+        var $print = $('#cp-app-code-print');
+        var $content = $('#cp-app-code-preview-content');
+        mkPrintButton(framework, $content, $print);
+
         mkHelpMenu(framework);
 
         var evModeChange = Util.mkEvent();

--- a/www/common/translations/messages.js
+++ b/www/common/translations/messages.js
@@ -172,7 +172,7 @@ define(function () {
 
     out.printText = "Print";
     out.printButton = "Print (enter)";
-    out.printButtonTitle = "Print your slides or export them as a PDF file";
+    out.printButtonTitle = "Print your document or export it as a PDF file";
     out.printOptions = "Layout options";
     out.printSlideNumber = "Display the slide number";
     out.printDate = "Display the date";


### PR DESCRIPTION
Hi,

This adds print functionality to the `/code` pad, as per feature request [#198](https://github.com/xwiki-labs/cryptpad/issues/198).

It's based on the implementation in the `/slide` pad. A new button is added under the "*More actions*" drop-down menu.

Couple points to note:

- Print button now has a more generic title text "*Print your document or export it as a PDF file*". This would now apply to the presentation pad as well, so translations will need to be updated. Alternatively, a custom button could be made for each type of pad with unique text.

- The final margins and page orientation depend heavily on local printer setup, so have been left to default for now (tested in Firefox, Chrome).

Let me know if any additions/fixes are required.
