### PR TITLE
Made CSP syntax in nginx example conf valid

### DIFF
--- a/docs/example.nginx.conf
+++ b/docs/example.nginx.conf
@@ -34,15 +34,15 @@ server {
     # Will not set any header if it is emptystring
     add_header Cache-Control $cacheControl;
 
-    set $styleSrc   "'unsafe-inline' 'self' your-main-domain.com";
-    set $scriptSrc  "'self' your-main-domain.com";
-    set $connectSrc "'self' https://your-main-domain.com wss://your-main-domain.com https://api.your-main-domain.com wss://your-main-domain.com your-main-domain.com blob: your-main-domain.com";
-    set $fontSrc    "'self' data: your-main-domain.com";
-    set $imgSrc     "data: * blob:";
-    set $frameSrc   "'self' your-sandbox-domain.com blob:";
-    set $mediaSrc "* blob:";
-    set $childSrc "https://your-main-domain.com";
-    set $workerSrc "https://your-main-domain.com";
+    set $styleSrc	"'unsafe-inline' 'self' your-main-domain.com";
+	set $scriptSrc	"'self' your-main-domain.com";
+	set $connectSrc	"'self' https://your-main-domain.com wss://your-main-domain.com your-main-domain.com https://api.your-main-domain.com blob: your-main-domain.com";
+	set $fontSrc	"'self' data: your-main-domain.com";
+	set $imgSrc	    "'self' data: * blob: your-main-domain.com";
+	set $frameSrc	"'self' your-sandbox-domain.com blob: your-sandbox-domain.com";
+	set $mediaSrc	"'self' data: * blob: your-main-domain.com";
+	set $childSrc	"https://your-main-domain.com";
+	set $workerSrc	"https://your-main-domain.com";
 
     set $unsafe 0;
     if ($uri = "/pad/inner.html") { set $unsafe 1; }


### PR DESCRIPTION
Made CSP syntax valid. There were arguments for e.g. blob: oder data: missing