### PR TITLE
Fix preparation of customize folder

### DIFF
--- a/container-start.sh
+++ b/container-start.sh
@@ -3,7 +3,7 @@
 # Creating customize folder
 mkdir -p customize
 [ -z "$(ls -A customize)" ] && echo "Creating customize folder" \
-  && cp -R customize.dist/* customize/ \
+  && mkdir customize/ \
   && cp config.example.js customize/config.js
 
 # Linking config.js


### PR DESCRIPTION
Following #336, and perhaps #339, this patch doesn't copy the whole `customize` directory to the docker container, but only the `config.js` file. This should allow for easier update of cryptpad.

Closes #336 