### PR TITLE
Add 2 missing volumes for blobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ VOLUME /cryptpad/blobstage
 VOLUME /cryptpad/pins
 VOLUME /cryptpad/tasks
 VOLUME /cryptpad/block
+VOLUME /cryptpad/blob
+VOLUME /cryptpad/blobstage
 
 # Required packages
 #   jq is a build only dependency, removed in cleanup stage


### PR DESCRIPTION
2 volumes were missing from the docker file. This PR adds them to the main Dockerfile.

They are present in the docker-compose.yml so this should be a non-issue for most users.