### PR TITLE
optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,26 @@
-# 6-stretch is the ONLY node 6 release supported by arm32v7, arm64v8 and x86-64 docker hub labels
-FROM node:6-stretch
+# We use multi stage builds
+FROM node:6-stretch-slim AS build
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq git jq python
+RUN npm install -g bower
+
+# install tini in this stage to avoid the need of jq and python
+# in the final image
+ADD docker-install-tini.sh /usr/local/bin/docker-install-tini.sh
+RUN /usr/local/bin/docker-install-tini.sh
+
+COPY . /cryptpad
+WORKDIR /cryptpad
+
+RUN npm install --production \
+    && npm install -g bower \
+    && bower install --allow-root
+
+FROM node:6-stretch-slim
 
 # You want USE_SSL=true if not putting cryptpad behind a proxy
 ENV USE_SSL=false
-ENV STORAGE=\'./storage/file\'
+ENV STORAGE="'./storage/file'"
 ENV LOG_TO_STDOUT=true
 
 # Persistent storage needs
@@ -16,36 +33,14 @@ VOLUME /cryptpad/block
 VOLUME /cryptpad/blob
 VOLUME /cryptpad/blobstage
 
-# Required packages
-#   jq is a build only dependency, removed in cleanup stage
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-         git jq python
+# Copy cryptpad and tini from the build container
+COPY --from=build /sbin/tini /sbin/tini
+COPY --from=build /cryptpad /cryptpad
 
-# Install tini for faux init
-#   sleep 1 is to ensure overlay2 can catch up with the copy prior to running chmod
-COPY ./docker-install-tini.sh / 
-RUN chmod a+x /docker-install-tini.sh \
-    && sleep 1 \
-    && /docker-install-tini.sh \
-    && rm /docker-install-tini.sh
-
-# Cleanup apt
-RUN apt-get remove -y --purge jq python \
-    && apt-get auto-remove -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install cryptpad
-COPY . /cryptpad
 WORKDIR /cryptpad
-RUN npm install --production \
-    && npm install -g bower \
-    && bower install --allow-root
 
 # Unsafe / Safe ports
 EXPOSE 3000 3001
 
 # Run cryptpad on startup
 CMD ["/sbin/tini", "--", "/cryptpad/container-start.sh"]
-


### PR DESCRIPTION
The current Dockerfile had multiple issues:

- uses a big debian image
- installation and removal of build dependencies happens in two steps
 - this does not shrink the image size, as all layers are preserved in the final image

Due issues with alpine, i switched to stretch-slim

Also i switched to multistage builds to make the resulting image more cache friendly