### PR TITLE
Nix packaging

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -45,7 +45,7 @@
     "localforage": "^1.5.2",
     "html2canvas": "^0.4.1",
     "croppie": "^2.5.0",
-    "sortablejs": "#^1.6.0",
+    "sortablejs": "^1.6.0",
     "saferphore": "^0.0.1",
     "jszip": "Stuk/jszip#^3.1.5",
     "requirejs-plugins": "^1.0.3"

--- a/lib/load-config.js
+++ b/lib/load-config.js
@@ -1,11 +1,14 @@
+/* jslint node: true */
+"use strict";
 var config;
+var configPath = process.env.CRYPTPAD_CONFIG || "../config/config";
 try {
-    config = require("../config/config");
+    config = require(configPath);
     if (config.adminEmail === 'i.did.not.read.my.config@cryptpad.fr') {
         console.log("You can configure the administrator email (adminEmail) in your config/config.js file");
     }
 } catch (e) {
-    console.log("You can customize the configuration by copying config/config.example.js to config/config.js");
+    console.log("Config not found, loading the example config. You can customize the configuration by copying config/config.example.js to " + configPath);
     config = require("../config/config.example");
 }
 module.exports = config;


### PR DESCRIPTION
Hi,

I am part of the NixOS Foundation. As part of the NLNet Zero grant we are helping accepted projects to package their project into nixpkgs. The goal is to provide a unified and composable way for all the grant's project to be used.

This PR includes a few changes that would make it easier to package cryptpad. A WIP package is available over there: https://github.com/NixOS/nixpkgs/pull/61513

The biggest outstanding difficulty that hasn't been addressed is that the project assumes that it's running from withing the source root. While a package generally has a binary installed in the PATH, the source somewhere in the /usr/lib and the data somewhere under /var like /var/lib/cryptpad. If you want cryptpad to be available in other package managers I recommend making these changes. If you want more details on how to apply those let me know.

Cheers,
z