### PR TITLE
Kanban: Move “Add Column” to Bottom

### DIFF
--- a/www/kanban/jkanban.js
+++ b/www/kanban/jkanban.js
@@ -509,13 +509,13 @@
                     var addBoard = document.createElement('div');
                     addBoard.id = 'kanban-addboard';
                     addBoard.setAttribute('class', 'fa fa-plus');
-                    boardContainerOuter.appendChild(addBoard);
 
                     self.container = boardContainer;
                     //add boards
                     self.addBoards(self.options.boards);
                     //appends to container
                     self.element.appendChild(boardContainerOuter);
+                    self.element.appendChild(addBoard);
 
                     // send event that board has changed
                     self.onChange();


### PR DESCRIPTION
This patch moves the button for adding new columns to kanban boards from
the top-right to the bottom-left. The reasoning behind this is that it's
not very often used (often only at the beginning when setting up the
board) but it is constantly taking space away from the columns. This is
annoying especially on mobile devices where it even moves all of the
columns to the left, leaving a larger border on the right.