### PR TITLE
Kanban: Move “Add Item” to Header

### DIFF
--- a/www/kanban/jkanban.js
+++ b/www/kanban/jkanban.js
@@ -395,17 +395,16 @@
                             contentBoard.appendChild(nodeItem);
                         }
                         //footer board
-                        var footerBoard = document.createElement('footer');
                         //add button
                         var addBoardItem = document.createElement('button');
-                        $(addBoardItem).addClass("kanban-additem btn btn-default fa fa-plus");
-                        footerBoard.appendChild(addBoardItem);
+                        addBoardItem.setAttribute('title', 'Add new item');
+                        $(addBoardItem).addClass("btn btn-default fa fa-plus");
+                        headerBoard.appendChild(addBoardItem);
                         __onAddItemClickHandler(addBoardItem);
 
                         //board assembly
                         boardNode.appendChild(headerBoard);
                         boardNode.appendChild(contentBoard);
-                        boardNode.appendChild(footerBoard);
                         //board add
                         self.container.appendChild(boardNode);
                     }


### PR DESCRIPTION
This patch moves the button to add new items to kanban boards to the
column headers.

The reasoning behind this change is that on larger boards the buttons at
the bottom may be pushed far away from the actual content, causing users
to constantly scroll up and down over the whole page just to add new
items. See the real-world example below.

This also helps on mobile devices since you may not see all of the
columns there due to the limited screen space. This means that you have
to remember which column you are working on to not accidentally add
items to the wrong column. This patch makes it clear to which  column
users add items since the button now resides next to the column title.

---

Example illustrating the issue to solve:

![Screenshot from 2019-10-09 22-05-31](https://user-images.githubusercontent.com/1008395/66517672-d4ca1500-eae3-11e9-8073-5bb1ec89d1b8.png)