### PR TITLE
Removed duplicate location ^~ /datastore/ block

### DIFF
--- a/docs/example.nginx.conf
+++ b/docs/example.nginx.conf
@@ -111,11 +111,6 @@ server {
         try_files $uri =404;
     }
 
-    location ^~ /datastore/ {
-        add_header Cache-Control max-age=0;
-        try_files $uri =404;
-    }
-
     location ~ ^/(register|login|settings|user|pad|drive|poll|slide|code|whiteboard|file|media|profile|contacts|todo|filepicker|debug|kanban|sheet|support|admin|notifications|teams)$ {
         rewrite ^(.*)$ $1/ redirect;
     }


### PR DESCRIPTION
The ```location ^~ /datastore/``` block was duplicate, meaning nginx would have balked on it during config check.