### PR TITLE
Log errors in faulty custom config file

### DIFF
--- a/lib/load-config.js
+++ b/lib/load-config.js
@@ -8,7 +8,14 @@ try {
         console.log("You can configure the administrator email (adminEmail) in your config/config.js file");
     }
 } catch (e) {
-    console.log("Config not found, loading the example config. You can customize the configuration by copying config/config.example.js to " + configPath);
+    if (e instanceof SyntaxError) {
+        console.error("config/config.js is faulty. See stacktrace below for more information. Terminating. \n");
+        console.error(e.name + ": " + e.message);
+        console.error(e.stack.split("\n\n")[0]);
+        process.exit(1);
+    } else {
+        console.log("Config not found, loading the example config. You can customize the configuration by copying config/config.example.js to " + configPath);
+    }
     config = require("../config/config.example");
 }
 module.exports = config;


### PR DESCRIPTION
CryptPAD now terminates and does not fallback to default config if the custom config is faulty.
The error in the custom config is logged to the terminal now.

Signed-off-by: Adrian Nöthlich <git@promasu.tech>