### PR TITLE
Check httpSafeOrigin in config variable

### DIFF
--- a/server.js
+++ b/server.js
@@ -55,7 +55,7 @@ if (process.env.PACKAGE) {
         config.httpPort = 3000;
     }
 
-    if (typeof(httpSafeOrigin) !== 'string') {
+    if (typeof(config.httpSafeOrigin) !== 'string') {
         if (typeof(config.httpSafePort) !== 'number') {
             config.httpSafePort = config.httpPort + 1;
         }


### PR DESCRIPTION
Noticed I was getting the warning and tracked it down to a missing `config.`