### PR TITLE
Add shutdown() to non-disk logger

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -96,7 +96,9 @@ Logger.create = function (config, cb) {
 
     if (!config.logPath) {
         console.log("No logPath configured. Logging to file disabled");
-        return void cb(Object.freeze(createMethods(ctx)));
+        var logger = createMethods(ctx);
+        logger.shutdown = noop;
+        return void cb(Object.freeze(logger));
     }
 
     Store.create({


### PR DESCRIPTION
The script `evict-inactive.js` calls `Log.shutdown()` at the end, which currently fails if logging to disk has been disabled via `logPath`.