### PR TITLE
Update nginx-configuration

### DIFF
--- a/docs/example.nginx.conf
+++ b/docs/example.nginx.conf
@@ -101,17 +101,17 @@ server {
     set $unsafe 0;
     # the following assets are loaded via the sandbox domain
     # they unfortunately still require exceptions to the sandboxing to work correctly.
-    if ($uri = "/pad/inner.html") { set $unsafe 1; }
-    if ($uri = "/sheet/inner.html") { set $unsafe 1; }
-    if ($uri ~ ^\/common\/onlyoffice\/.*\/index\.html.*$) { set $unsafe 1; }
+    #if ($uri = "/pad/inner.html") { set $unsafe 1; }
+    #if ($uri = "/sheet/inner.html") { set $unsafe 1; }
+    #if ($uri ~ ^\/common\/onlyoffice\/.*\/index\.html.*$) { set $unsafe 1; }
 
     # everything except the sandbox domain is a privileged scope, as they might be used to handle keys
     if ($host != $sandbox_domain) { set $unsafe 0; }
 
     # privileged contexts allow a few more rights than unprivileged contexts, though limits are still applied
-    if ($unsafe) {
-        set $scriptSrc "'self' 'unsafe-eval' 'unsafe-inline' resource: ${main_domain}";
-    }
+    #if ($unsafe) {
+     #   set $scriptSrc "'self' 'unsafe-eval' 'unsafe-inline' resource: ${main_domain}";
+    #}
 
     # Finally, set all the rules you composed above.
     add_header Content-Security-Policy "default-src 'none'; child-src $childSrc; worker-src $workerSrc; media-src $mediaSrc; style-src $styleSrc; script-src $scriptSrc; connect-src $connectSrc; font-src $fontSrc; img-src $imgSrc; frame-src $frameSrc;";


### PR DESCRIPTION
Tested on Debian buster; Nodejs v12.16.1: 

The properties 'unsafe-eval' and 'unsafe-inline' in script-src causes bugs with CSP, preventing Sheets to work when installing Cryptpad on self hosting.
Commenting them is enough to work most cases, I let them commented in case someone wants to test other configurations.