### PR TITLE
add 'color by author' to code app

### DIFF
--- a/www/code/inner.js
+++ b/www/code/inner.js
@@ -305,7 +305,7 @@ define([
         $removeAuthorColorsButton.click(function() {
             selfrom = editor.getCursor("from");
             selto = editor.getCursor("to");
-            if (selfrom == selto) {
+            if (!editor.somethingSelected() || selfrom == selto) {
                 editor.getAllMarks().forEach(marker => marker.clear());
             } else {
                 editor.findMarks(selfrom, selto).forEach(marker => marker.clear());

--- a/www/code/inner.js
+++ b/www/code/inner.js
@@ -459,7 +459,12 @@ define([
         editor.on('change', function( cm, change ) {
             if (change.origin == "+input" || change.origin == "paste") {
                 // add new author mark if text is added. marks from removed text are removed automatically
-                editor.markText({line: change.from.line, ch: change.from.ch}, {line: change.from.line + change.text.length-1, ch: change.from.ch + change.text[change.text.length-1].length}, {css: "background-color: " + authorcolor});
+                if (change.text.length > 1) {
+                    to_ch = change.text[change.text.length-1].length; 
+                } else {
+                    to_ch = change.from.ch + change.text[change.text.length-1].length;                
+                }
+                editor.markText({line: change.from.line, ch: change.from.ch}, {line: change.from.line + change.text.length-1, ch: to_ch}, {css: "background-color: " + authorcolor});
             } else if (change.origin == "setValue") {
                 // on remote update: remove all marks, add new marks
                 editor.getAllMarks().forEach(marker => marker.clear());

--- a/www/code/inner.js
+++ b/www/code/inner.js
@@ -382,23 +382,29 @@ define([
 
             // get author marks
             var authormarks = [];
+            var colorlist = [];
             editor.getAllMarks().forEach(function (mark) {
                 var pos = mark.find();
                 var css = mark.css;
                 if (pos !== undefined && css !== undefined) {
                     var color = css.replace("background-color:", "").trim();
+                    var colorIndex = colorlist.indexOf(color);
+                    if (colorIndex === -1) {
+                        colorlist.push(color);
+                        colorIndex = colorlist.length-1;
+                    }
                     if (pos.from.line === pos.to.line) {
                         if ((pos.from.ch + 1) === pos.to.ch) {
-                            authormarks.push([pos.from.line, pos.from.ch, color]);
+                            authormarks.push([colorIndex, pos.from.line, pos.from.ch]);
                         } else {
-                            authormarks.push([pos.from.line, pos.from.ch, pos.to.ch, color]);
+                            authormarks.push([colorIndex, pos.from.line, pos.from.ch, pos.to.ch]);
                         }
                     } else {
-                        authormarks.push([pos.from.line, pos.from.ch, pos.to.line, pos.to.ch, color]);
+                        authormarks.push([colorIndex, pos.from.line, pos.from.ch, pos.to.line, pos.to.ch]);
                     }
                 }
             });
-            content.authormarks = authormarks;
+            content.authormarks = {marks: authormarks, colorlist: colorlist};
             authormarksLocal = authormarks.slice();
 
             return content;
@@ -484,32 +490,31 @@ define([
                 editor.getAllMarks().forEach(function (marker) {
                     marker.clear();
                 });
-                authormarksUpdate.forEach(function (mark) {
+                authormarksUpdate.marks.forEach(function (mark) {
                     var from_line;
                     var to_line;
                     var from_ch;
                     var to_ch;
-                    var mark_color;
+                    var colorIndex = mark[0];
+                    if (authormarksUpdate.colorlist === undefined || (authormarksUpdate.colorlist.length < (colorIndex+1))) { return; }
+                    var color = authormarksUpdate.colorlist[colorIndex];
                     if (mark.length === 3)  {
-                        from_line = mark[0];
-                        to_line = mark[0];
-                        from_ch = mark[1];
-                        to_ch = mark[1]+1;
-                        mark_color = mark[2];
+                        from_line = mark[1];
+                        to_line = mark[1];
+                        from_ch = mark[2];
+                        to_ch = mark[2]+1;
                     } else if (mark.length === 4) {
-                        from_line = mark[0];
-                        to_line = mark[0];
-                        from_ch = mark[1];
-                        to_ch = mark[2];
-                        mark_color = mark[3];
-                    } else if (mark.length === 5) {
-                        from_line = mark[0];
-                        to_line = mark[2];
-                        from_ch = mark[1];
+                        from_line = mark[1];
+                        to_line = mark[1];
+                        from_ch = mark[2];
                         to_ch = mark[3];
-                        mark_color = mark[4];
+                    } else if (mark.length === 5) {
+                        from_line = mark[1];
+                        to_line = mark[3];
+                        from_ch = mark[2];
+                        to_ch = mark[4];
                     }
-                    editor.markText({line: from_line, ch: from_ch}, {line: to_line, ch: to_ch}, {css: "background-color: " + mark_color});
+                    editor.markText({line: from_line, ch: from_ch}, {line: to_line, ch: to_ch}, {css: "background-color: " + color});
                 });
             }
             framework.localChange();

--- a/www/code/inner.js
+++ b/www/code/inner.js
@@ -307,7 +307,9 @@ define([
             var selto = editor.getCursor("to");
             if (!editor.somethingSelected() || selfrom === selto) {
                 editor.getAllMarks().forEach(function (marker) {
-                    marker.clear();
+                    if (marker.attributes !== undefined && marker.attributes['data-type'] === 'authorcolor') {
+                        marker.clear();
+                    }
                 });
             } else {
                 editor.findMarks(selfrom, selto).forEach(function (marker) {
@@ -385,9 +387,9 @@ define([
             var colorlist = [];
             editor.getAllMarks().forEach(function (mark) {
                 var pos = mark.find();
-                var css = mark.css;
-                if (pos !== undefined && css !== undefined) {
-                    var color = css.replace("background-color:", "").trim();
+                var attributes = mark.attributes;
+                if (pos !== undefined && attributes !== undefined && attributes['data-color'] !== undefined && attributes['data-type'] === "authorcolor") {
+                    var color = attributes['data-color'];
                     var colorIndex = colorlist.indexOf(color);
                     if (colorIndex === -1) {
                         colorlist.push(color);
@@ -484,11 +486,13 @@ define([
                 } else {
                     to_ch_add = change.from.ch + change.text[change.text.length-1].length;                
                 }
-                editor.markText({line: change.from.line, ch: change.from.ch}, {line: change.from.line + change.text.length-1, ch: to_ch_add}, {css: "background-color: " + authorcolor});
+                editor.markText({line: change.from.line, ch: change.from.ch}, {line: change.from.line + change.text.length-1, ch: to_ch_add}, {css: "background-color: " + authorcolor, attributes: {'data-type': 'authorcolor', 'data-color': authorcolor}});
             } else if (change.origin === "setValue") {
                 // on remote update: remove all marks, add new marks
                 editor.getAllMarks().forEach(function (marker) {
-                    marker.clear();
+                    if (marker.attributes !== undefined && marker.attributes['data-type'] === 'authorcolor') {
+                        marker.clear();
+                    }
                 });
                 authormarksUpdate.marks.forEach(function (mark) {
                     var from_line;
@@ -514,7 +518,7 @@ define([
                         from_ch = mark[2];
                         to_ch = mark[4];
                     }
-                    editor.markText({line: from_line, ch: from_ch}, {line: to_line, ch: to_ch}, {css: "background-color: " + color});
+                    editor.markText({line: from_line, ch: from_ch}, {line: to_line, ch: to_ch}, {css: "background-color: " + color, attributes: {'data-type': 'authorcolor', 'data-color': color}});
                 });
             }
             framework.localChange();

--- a/www/code/inner.js
+++ b/www/code/inner.js
@@ -300,6 +300,20 @@ define([
         var previewPane = mkPreviewPane(editor, CodeMirror, framework, isPresentMode);
         var markdownTb = mkMarkdownTb(editor, framework);
 
+        var $removeAuthorColorsButton = framework._.sfCommon.createButton('removeauthorcolors', true, {icon: 'fa-paint-brush', title: 'Autorenfarben entfernen'});
+        framework._.toolbar.$rightside.append($removeAuthorColorsButton);
+        $removeAuthorColorsButton.click(function() {
+            selfrom = editor.getCursor("from");
+            selto = editor.getCursor("to");
+            if (selfrom == selto) {
+                editor.getAllMarks().forEach(marker => marker.clear());
+            } else {
+                editor.findMarks(selfrom, selto).forEach(marker => marker.clear());
+            }
+            framework.localChange();
+        });
+
+        var authormarksLocal = [];
         var authormarksUpdate = [];
 
         var $print = $('#cp-app-code-print');
@@ -352,7 +366,7 @@ define([
             // author marks will be updated in onChange-Handler
             authormarksUpdate = newContent.authormarks;
 
-            CodeMirror.contentUpdate(newContent);
+            CodeMirror.contentUpdate(newContent, authormarksUpdate, authormarksLocal);
             previewPane.draw();
         });
 
@@ -372,6 +386,7 @@ define([
                 }
             });
             content.authormarks = authormarks;
+            authormarksLocal = authormarks.slice();
 
             return content;
         });

--- a/www/code/inner.js
+++ b/www/code/inner.js
@@ -346,20 +346,7 @@ define([
         
         // get user color for author marks
         var authorcolor = framework._.sfCommon.getMetadataMgr().getUserData().color;
-        var authorcolor_r = parseInt("0x" + authorcolor.slice(1,3));
-        var authorcolor_g = parseInt("0x" + authorcolor.slice(3,5));
-        var authorcolor_b = parseInt("0x" + authorcolor.slice(5,7));
-        var authorcolor_min = Math.min(authorcolor_r, authorcolor_g, authorcolor_b);
-
-        // set minimal brightness for author marks and calculate color
-        var tarMinColorVal = 180;
-        if (authorcolor_min < tarMinColorVal) {
-            var facColor = (255-tarMinColorVal)/(255-authorcolor_min);
-            authorcolor_r = Math.floor(255-facColor*(255-authorcolor_r));
-            authorcolor_g = Math.floor(255-facColor*(255-authorcolor_g));
-            authorcolor_b = Math.floor(255-facColor*(255-authorcolor_b));
-            authorcolor = "#" + authorcolor_r.toString(16) + authorcolor_g.toString(16) + authorcolor_b.toString(16);
-        }
+        var authorcolorOpacity = "90";
 
         ////
 
@@ -486,7 +473,7 @@ define([
                 } else {
                     to_ch_add = change.from.ch + change.text[change.text.length-1].length;                
                 }
-                editor.markText({line: change.from.line, ch: change.from.ch}, {line: change.from.line + change.text.length-1, ch: to_ch_add}, {css: "background-color: " + authorcolor, attributes: {'data-type': 'authorcolor', 'data-color': authorcolor}});
+                editor.markText({line: change.from.line, ch: change.from.ch}, {line: change.from.line + change.text.length-1, ch: to_ch_add}, {css: "background-color: " + authorcolor + authorcolorOpacity, attributes: {'data-type': 'authorcolor', 'data-color': authorcolor}});
             } else if (change.origin === "setValue") {
                 // on remote update: remove all marks, add new marks
                 editor.getAllMarks().forEach(function (marker) {
@@ -518,7 +505,7 @@ define([
                         from_ch = mark[2];
                         to_ch = mark[4];
                     }
-                    editor.markText({line: from_line, ch: from_ch}, {line: to_line, ch: to_ch}, {css: "background-color: " + color, attributes: {'data-type': 'authorcolor', 'data-color': color}});
+                    editor.markText({line: from_line, ch: from_ch}, {line: to_line, ch: to_ch}, {css: "background-color: " + color + authorcolorOpacity, attributes: {'data-type': 'authorcolor', 'data-color': color}});
                 });
             }
             framework.localChange();

--- a/www/common/sframe-common-codemirror.js
+++ b/www/common/sframe-common-codemirror.js
@@ -418,12 +418,12 @@ define([
 
 
 
-        exp.contentUpdate = function (newContent) {
+        exp.contentUpdate = function (newContent, authormarksUpdate, authormarksLocal) {
             var oldDoc = canonicalize(editor.getValue());
             var remoteDoc = newContent.content;
             // setValueAndCursor triggers onLocal, even if we don't make any change to the content
             // and it may revert other changes (metadata)
-            if (oldDoc === remoteDoc) { return; }
+            if (oldDoc === remoteDoc && authormarksUpdate == authormarksLocal) { return; }
             exp.setValueAndCursor(oldDoc, remoteDoc);
         };
 

--- a/www/common/sframe-common-codemirror.js
+++ b/www/common/sframe-common-codemirror.js
@@ -423,7 +423,7 @@ define([
             var remoteDoc = newContent.content;
             // setValueAndCursor triggers onLocal, even if we don't make any change to the content
             // and it may revert other changes (metadata)
-            if (oldDoc === remoteDoc && authormarksUpdate == authormarksLocal) { return; }
+            if (oldDoc === remoteDoc && (authormarksUpdate === undefined || authormarksLocal === undefined || JSON.stringify(authormarksUpdate) === JSON.stringify(authormarksLocal))) { return; }
             exp.setValueAndCursor(oldDoc, remoteDoc);
         };
 


### PR DESCRIPTION
Added a "color by author" feature to the code app.

The `markText`-method of CodeMirror is used in the `onChange`-event to mark new inputs with a background-color.
In the contentGetter all marks are read and stored in an array besides the text content.
When a remote change occurs, the changes in the content will then again trigger the `onChange`-event of the editor, where old marks are deleted and the new marks are created.

The colors can be partially or completely removed with an additional button.