### PR TITLE
Allow config.defaultStorageLimit to be zero bytes

### DIFF
--- a/lib/historyKeeper.js
+++ b/lib/historyKeeper.js
@@ -98,7 +98,7 @@ module.exports.create = function (config, cb) {
     paths.staging = keyOrDefaultString('blobStagingPath', './blobstage');
     paths.blob = keyOrDefaultString('blobPath', './blob');
 
-    Env.defaultStorageLimit = typeof(config.defaultStorageLimit) === 'number' && config.defaultStorageLimit > 0?
+    Env.defaultStorageLimit = typeof(config.defaultStorageLimit) === 'number' && config.defaultStorageLimit >= 0?
         config.defaultStorageLimit:
         Core.DEFAULT_LIMIT;
 


### PR DESCRIPTION
Hi cryptpad-team,

since commit f86196e40adfccade922e63bba5dafbff20538fe config.defaultStorageLimit cannot be zero anymore. I suppose this might break some configurations.

While https://github.com/xwiki-labs/cryptpad/blob/c8c98b57479637484b36ba43e14c45671cdcffe8/lib/load-config.js#L35 allows it to be >= 0, https://github.com/xwiki-labs/cryptpad/blob/f86196e40adfccade922e63bba5dafbff20538fe/lib/historyKeeper.js#L82 requires it to be > 0.

Greetings,
Alex