### PR TITLE
Finnish language renamed in a correct way

### DIFF
--- a/customize.dist/messages.js
+++ b/customize.dist/messages.js
@@ -5,7 +5,7 @@ var map = {
     'de': 'Deutsch',
     'el': 'Ελληνικά',
     'es': 'Español',
-    'fi': 'Suomalainen',
+    'fi': 'Suomi',
     'fr': 'Français',
     //'hi': 'हिन्दी',
     'it': 'Italiano',


### PR DESCRIPTION
Have a good day.
As cited at #609 there is a problem at naming _finnish_ so this change is needed in order to provide correctness.