### PR TITLE
Unsafe Origin for CSP modified and Migration script fixed

### DIFF
--- a/config/config.example.js
+++ b/config/config.example.js
@@ -46,7 +46,7 @@ module.exports = {
  *  cryptpad/docs/example.nginx.conf (see the $main_domain variable)
  *
  */
-    httpUnsafeOrigin: 'http://127.0.0.1:3000/',
+    httpUnsafeOrigin: 'http://127.0.0.1:3000/ http://localhost:3000',
 
 /*  httpSafeOrigin is the URL that is used for the 'sandbox' described above.
  *  If you're testing or developing with CryptPad on your local machine then

--- a/config/config.example.js
+++ b/config/config.example.js
@@ -46,7 +46,7 @@ module.exports = {
  *  cryptpad/docs/example.nginx.conf (see the $main_domain variable)
  *
  */
-    httpUnsafeOrigin: 'http://localhost:3000/',
+    httpUnsafeOrigin: 'http://127.0.0.1:3000/',
 
 /*  httpSafeOrigin is the URL that is used for the 'sandbox' described above.
  *  If you're testing or developing with CryptPad on your local machine then

--- a/scripts/migrations/migrate-tasks-v1.js
+++ b/scripts/migrations/migrate-tasks-v1.js
@@ -8,14 +8,14 @@ var config = require("../../lib/load-config");
 // but the API requires it, and I don't feel like changing that
 // --ansuz
 var FileStorage = require("../../lib/storage/file");
-
 var tasks;
 nThen(function (w) {
     Logger.create(config, w(function (_log) {
         config.log = _log;
     }));
 }).nThen(function (w) {
-    FileStorage.create(config, w(function (_store) {
+    FileStorage.create(config, w(function (err, _store) {
+	if (err) { throw err; }
         config.store = _store;
     }));
 }).nThen(function (w) {


### PR DESCRIPTION
In order to be able to load the webpage locally using `localhost` or `127.0.0.1` this change is required.
Content Security Policy could accept different domain names using whitespace as separator.
When running `npm start` at the shell the server is loaded at `127.0.0.1` but localhost was the one specified at the _Unsafe Origin_ configuration example.
In this way, both `localhost` and `127.0.0.1` could be used to access the current development server.