### PR TITLE
Set reasonable env value for $PWD

### DIFF
--- a/docs/cryptpad.service
+++ b/docs/cryptpad.service
@@ -17,7 +17,7 @@ SyslogIdentifier=cryptpad
 User=cryptpad
 Group=cryptpad
 # modify to match your working directory
-Environment='PWD="/home/cryptpad/cryptpad/cryptpad"'
+Environment='PWD="/home/cryptpad/cryptpad"'
 
 # systemd sets the open file limit to 4000 unless you override it
 # cryptpad stores its data with the filesystem, so you should increase this to match the value of `ulimit -n`


### PR DESCRIPTION
/home/cryptpad/cryptpad/cryptpad seems one cryptpad too many, and it does not match the sample value of WorkingDirectory above