### PR TITLE
Support non-writable working directory

### DIFF
--- a/config/config.example.js
+++ b/config/config.example.js
@@ -295,6 +295,8 @@ module.exports = {
      */
     blobStagingPath: './data/blobstage',
 
+    decreePath: './data/decrees',
+
     /* CryptPad supports logging events directly to the disk in a 'logs' directory
      * Set its location here, or set it to false (or nothing) if you'd rather not log
      */

--- a/lib/historyKeeper.js
+++ b/lib/historyKeeper.js
@@ -122,6 +122,7 @@ module.exports.create = function (Env, cb) {
         // create a pin store
         Store.create({
             filePath: pinPath,
+            archivePath: Env.paths.archive,
         }, w(function (err, s) {
             if (err) { throw err; }
             Env.pinStore = s;
@@ -130,7 +131,7 @@ module.exports.create = function (Env, cb) {
         // create a channel store
         Store.create({
             filePath: Env.paths.data,
-            archivepath: Env.paths.archive,
+            archivePath: Env.paths.archive,
         }, w(function (err, _store) {
             if (err) { throw err; }
             Env.msgStore = _store; // API used by rpc

--- a/lib/log.js
+++ b/lib/log.js
@@ -87,6 +87,7 @@ Logger.create = function (config, cb) {
 
     Store.create({
         filePath: config.logPath,
+        archivePath: config.archivePath,
     }, function (err, store) {
         if (err) {
             throw err;

--- a/lib/workers/db-worker.js
+++ b/lib/workers/db-worker.js
@@ -63,6 +63,7 @@ const init = function (config, _cb) {
         }));
         Store.create({
             filePath: config.pinPath,
+            archivePath: config.archivePath,
         }, w(function (err, _pinStore) {
             if (err) {
                 w.abort();


### PR DESCRIPTION
Mixing code and data in the same writable directory is a security risk. Mitigating it requires running CryptPad as a user that doesn't have write permissions to the source tree, and configuring all data paths to be under a directory that user can write (e.g. source under /home/cryptpad/cryptpad and data under /var/lib/cryptpad).

Without these patches, some places in CryptPad fall back to PWD based paths and fail with EACCESS.