### PR TITLE
Improve Markdown Heading Styling

### DIFF
--- a/customize.dist/src/less2/include/markdown.less
+++ b/customize.dist/src/less2/include/markdown.less
@@ -163,6 +163,10 @@
         font-weight: bold;
         padding-bottom: 0.3em;
         border-bottom: 1px solid @cp_markdown-border;
+        margin-top: 1em;
+    }
+    h4, h5, h6 {
+        border-bottom: none;
     }
     li {
         min-height: 22px;


### PR DESCRIPTION
Hey there! This project is _very_ cool!

I just found this today and _might_ be contributing more if I can find the time. For now, here's a quick PR to ( subjectively ) improve the heading sytle in the markdown editor.

### Before

![image](https://user-images.githubusercontent.com/25393315/120874237-6e70f080-c56b-11eb-9d47-7d914e607483.png)

### After

![image](https://user-images.githubusercontent.com/25393315/120874292-995b4480-c56b-11eb-9276-3e85c6969972.png)
