### PR TITLE
Remove 'Japanese translation' from WIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@
 * form templates
 * guard against a type error in `getAccessKeys`
 * guard against invalid or malicious input when constructing media-tags for embedding in markdown
-* Japanese translation
 * conversions
   * convert app
   * some basic office formats


### PR DESCRIPTION
Thanks to the recent work it has achieved 100%. See the latest commit: 9ad74aeba106c01b8c9baabab5ef9b0e599b4b88