### PR TITLE
Example NGINX config: allow embedding only from main_domain

### DIFF
--- a/docs/example.nginx.conf
+++ b/docs/example.nginx.conf
@@ -59,7 +59,8 @@ server {
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;
     add_header Access-Control-Allow-Origin "*";
-    # add_header X-Frame-Options "SAMEORIGIN";
+    # Allow embedding only from main_domain - this is a legacy option for older browsers (see CSP section for modern implementation)
+    add_header X-Frame-Options "allow-from https://${main_domain}";
 
     # Opt out of Google's FLoC Network
     add_header Permissions-Policy interest-cohort=();

--- a/docs/example.nginx.conf
+++ b/docs/example.nginx.conf
@@ -101,6 +101,10 @@ server {
     # this prevents loading any iframes from anywhere other than the sandbox domain
     set $frameSrc   "'self' https://${sandbox_domain} blob:";
 
+    # frame-ancestors specifies valid parents that may embed a page.
+    # this prevents embedding anywhere other than the main domain
+    set $frameAnc   "'self' https://${main_domain}";
+
     # specifies valid sources for loading media using video or audio
     set $mediaSrc   "blob:";
 
@@ -135,7 +139,7 @@ server {
     }
 
     # Finally, set all the rules you composed above.
-    add_header Content-Security-Policy "default-src 'none'; child-src $childSrc; worker-src $workerSrc; media-src $mediaSrc; style-src $styleSrc; script-src $scriptSrc; connect-src $connectSrc; font-src $fontSrc; img-src $imgSrc; frame-src $frameSrc;";
+    add_header Content-Security-Policy "default-src 'none'; child-src $childSrc; worker-src $workerSrc; media-src $mediaSrc; style-src $styleSrc; script-src $scriptSrc; connect-src $connectSrc; font-src $fontSrc; img-src $imgSrc; frame-src $frameSrc; frame-ancestors $frameAnc;";
 
     # The nodejs process can handle all traffic whether accessed over websocket or as static assets
     # We prefer to serve static content from nginx directly and to leave the API server to handle


### PR DESCRIPTION
While `frame-src` already restricts what `main_domain` can embed the other direction was missing. Adding `frame-ancestors` closes the loop - only content from `sandbox_domain` can solely be embedded from `main_domain`.

The second commit implements the same measure for old browsers - I just added it for completeness but I can remove it if you think it is superfluous.

Tested for some days now with no regression (I also tested the new OnlyOffice components).