### PR TITLE
update example.nginx.conf to listen on ipv6 too

### DIFF
--- a/docs/example.nginx.conf
+++ b/docs/example.nginx.conf
@@ -6,6 +6,7 @@
 
 server {
     listen 443 ssl http2;
+    listen [::]:443 ssl http2; # ipv6
 
     # CryptPad serves static assets over these two domains.
     # `main_domain` is what users will enter in their address bar.


### PR DESCRIPTION
A admin only using ipv4 might overlook this configuration entry and make his cryptpad-instance only available on ipv4. Unintentionally locking-out every ipv6 user.

This change allows ipv4 and ipv6 access.