### PR TITLE
add Weblate widget showing language translation progress

### DIFF
--- a/customize.dist/translations/README.md
+++ b/customize.dist/translations/README.md
@@ -1,6 +1,8 @@
 # Translations
 
-Translations can now be made using [Weblate](https://weblate.cryptpad.fr). We may still accept PRs for the internal translation files, but we won't provide support for this.
+Translations can now be made using [Weblate](https://weblate.cryptpad.fr). We may still accept PRs for the internal translation files, but we won't provide support for this. See the state of the translated languages:
+
+![](https://weblate.cryptpad.fr/widgets/cryptpad/-/app/multi-auto.svg)
 
 ## Request a new language
 

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,10 @@ meet our strict criteria for safety.
 # Translations
 
 CryptPad can be translated with nothing more than a web browser via our
-[Weblate instance](https://weblate.cryptpad.fr/projects/cryptpad/app/).
+[Weblate instance](https://weblate.cryptpad.fr/projects/cryptpad/app/). See the state of the translated languages:
+
+![](https://weblate.cryptpad.fr/widgets/cryptpad/-/app/multi-auto.svg)
+
 More information about this can be found in [our translation guide](/customize.dist/translations/README.md).
 
 # Contacting Us


### PR DESCRIPTION
Here is a small proposal to include some Weblate "widget" on our repository `README.md` files. I believe it would facilitate translation contributions.

Right now, potential contributors have to go through Weblate projects, search for the language they might know. Having these stats right on our repo they'll get the information sooner and might get motivated to contribute.

See how it currently look:

<img width="843" alt="Screenshot 2022-08-25 at 11 16 35" src="https://user-images.githubusercontent.com/41020854/186626185-fe9a3093-9ae2-4c19-becc-ee383620240e.png">


As discussed with @davidbenque, we don't really like the look of the widget. The fact that the languages aren't sorted in particular order isn't great too. We might want to try other widgets, but [the Weblate page looks kinda broken](https://weblate.cryptpad.fr/widgets/cryptpad/?component=app) (probably an HTTP/HTTPS mismatch).