### PR TITLE
Add OCSP stapling support

### DIFF
--- a/customize.dist/translations/README.md
+++ b/customize.dist/translations/README.md
@@ -1,6 +1,8 @@
 # Translations
 
-Translations can now be made using [Weblate](https://weblate.cryptpad.fr). We may still accept PRs for the internal translation files, but we won't provide support for this.
+Translations can now be made using [Weblate](https://weblate.cryptpad.fr). We may still accept PRs for the internal translation files, but we won't provide support for this. See the state of the translated languages:
+
+![](https://weblate.cryptpad.fr/widgets/cryptpad/-/app/multi-auto.svg)
 
 ## Request a new language
 

--- a/docs/example.nginx.conf
+++ b/docs/example.nginx.conf
@@ -65,6 +65,11 @@ server {
     ssl_ciphers EECDH+AESGCM:EDH+AESGCM;
     ssl_ecdh_curve secp384r1; # Requires nginx >= 1.1.0
 
+    # OCSP Stapling
+    # fetch OCSP records from URL in ssl_certificate and cache them
+    ssl_stapling on;
+    ssl_stapling_verify on;
+
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,10 @@ meet our strict criteria for safety.
 # Translations
 
 CryptPad can be translated with nothing more than a web browser via our
-[Weblate instance](https://weblate.cryptpad.fr/projects/cryptpad/app/).
+[Weblate instance](https://weblate.cryptpad.fr/projects/cryptpad/app/). See the state of the translated languages:
+
+![](https://weblate.cryptpad.fr/widgets/cryptpad/-/app/multi-auto.svg)
+
 More information about this can be found in [our translation guide](/customize.dist/translations/README.md).
 
 # Contacting Us


### PR DESCRIPTION
Here is a PR to add [OCSP](https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol) stapling support to our Nginx example configuration file.

Benefits:
- Quicker loads
- Less resources consumption

Disadvantage: may have been source of issues due to poor implementation years ago, everything must have been fixed now but we can't guarantee it will works well on a **very** outdated web server.

For these dinosaurs still out here, it may be useful to add the `resolver` parameters too. But it would add some dependency to third part service (if a local one isn't installed):
```nginx
resolver X.X.X.X Y.Y.Y.Y valid=300s;
resolver_timeout 5s;
``` 

What do you think?