### PR TITLE
Make unparseable message non-fatal

### DIFF
--- a/www/common/outer/worker-channel.js
+++ b/www/common/outer/worker-channel.js
@@ -171,10 +171,12 @@ define([
             var data;
             // apparently some browser extensions send messages to random targets
             // which can trigger parse errors that interrupt normal behaviour
+            // we therefore log a warning and ignore any messages we can't parse
             try {
                 data = typeof(msg.data) === "object" ? msg.data : JSON.parse(msg.data);
             } catch (err) {
-                console.error(err);
+                console.warn(err);
+                return;
             }
             if (typeof(data.ack) !== "undefined") {
                 if (acks[data.txid]) { acks[data.txid](!data.ack); }


### PR DESCRIPTION
There was code to handle unparseable messages from things like third party browser extensions but it caught a JSON parsing error, logged an error and then continued, which would throw an unhandled exception trying to read the `ack` property of `data` which had been left as `undefined`.

Add a `return` to abort execution of the handler function and ignore the message instead. Also changes the error to warning, since it's not a fatal error. Add a comment to clarify the behaviour.

From the existing comment, it looks like this was the original intention of the code, but the `return` was simply missed.