### PR TITLE
Rename 'Copy link' to 'Copy submission link' on forms

### DIFF
--- a/www/common/translations/messages.json
+++ b/www/common/translations/messages.json
@@ -1354,7 +1354,7 @@
     "form_preview": "Preview form",
     "form_changeTypeConfirm": "Select the new question type.",
     "form_corruptAnswers": "This form already has responses. Changing this question type may invalidate previous response data.",
-    "form_geturl": "Copy link",
+    "form_geturl": "Copy submission link",
     "toolbar_preview": "Preview",
     "form_updateMsg": "Update submit message",
     "form_addMsg": "Add submit message",


### PR DESCRIPTION
As requested [here](https://github.com/xwiki-labs/cryptpad/issues/937), renamed the button to share the public submission link to forms, in order to avoid confusion. 