### PR TITLE
Move pad resize button

### DIFF
--- a/www/pad/app-pad.less
+++ b/www/pad/app-pad.less
@@ -78,18 +78,15 @@ body.cp-app-pad {
     }
     #cp-app-pad-resize {
         order: 2;
+        position: relative;
         height: 28px;
         width: 36px;
-        margin-left: -40px;
+        margin-left: 10px;
         margin-top: 10px;
-        margin-right: 0;
+        margin-right: 0px;
         button {
-            color: @cp_pad-resize;
-            border-color: @cp_pad-resize;
-        }
-        &.hidden {
-            margin-left: -70px;
-            margin-right: 40px;
+            color: @cp_pad-fg;
+            border-color: @cp_pad-fg;
         }
     }
     #cp-app-pad-toc {


### PR DESCRIPTION
As requested [here](https://github.com/xwiki-labs/cryptpad/issues/957), moved the pad resize button to the right of the pad, so that it no longer hovers over/overlaps with the text in the pad. 