### PR TITLE
Added Rich Text CKeditor autocorrect plugin to allow automatic creation of bullet lists

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -48,7 +48,8 @@
     "jszip": "3.7.1",
     "requirejs-plugins": "^1.0.3",
     "dragula.js": "3.7.2",
-    "MathJax": "3.0.5"
+    "MathJax": "3.0.5",
+    "autocorrect": "https://download.ckeditor.com/autocorrect/releases/autocorrect_3.0.zip"
   },
   "resolutions": {
     "bootstrap": "^v4.0.0",

--- a/customize.dist/ckeditor-config.js
+++ b/customize.dist/ckeditor-config.js
@@ -10,7 +10,7 @@ CKEDITOR.editorConfig = function( config ) {
     // document itself and causes problems when it's sent across the wire and reflected back
     config.removePlugins= 'resize,elementspath';
     config.resize_enabled= false; //bottom-bar
-    config.extraPlugins= 'autolink,colorbutton,colordialog,font,indentblock,justify,mediatag,print,blockbase64,mathjax,wordcount,comments';
+    config.extraPlugins= 'autocorrect,autolink,colorbutton,colordialog,font,indentblock,justify,mediatag,print,blockbase64,mathjax,wordcount,comments';
     config.toolbarGroups= [
         // {"name":"clipboard","groups":["clipboard","undo"]},
         //{"name":"editing","groups":["find","selection"]},

--- a/www/pad/inner.js
+++ b/www/pad/inner.js
@@ -1365,6 +1365,7 @@ define([
                 Ckeditor.plugins.addExternal('blockbase64', '/pad/', 'disable-base64.js');
                 Ckeditor.plugins.addExternal('comments', '/pad/', 'comment.js');
                 Ckeditor.plugins.addExternal('wordcount', '/pad/wordcount/', 'plugin.js');
+                Ckeditor.plugins.addExternal('autocorrect', '../autocorrect/', 'plugin.js');
 
 /*  CKEditor4 is, by default, incompatible with strong CSP settings due to the
     way it loads a variety of resources and event handlers by injecting HTML


### PR DESCRIPTION
As requested [here](https://github.com/xwiki-labs/cryptpad/issues/307), added a CKeditor autocorrect plugin which, amongst other things, allows the automatic creation of bullet lists by typing '*'. The plugin installs as a bower dependency. Other functionalities provided by the autocorrectplugin are listed [here](https://ckeditor.com/cke4/addon/autocorrect).