### PR TITLE
Default dark theme switch

### DIFF
--- a/www/common/boot2.js
+++ b/www/common/boot2.js
@@ -3,6 +3,7 @@ define([
     '/customize/application_config.js'
 ], function (RequireConfig, AppConfig) {
 
+    // if an AppConfig.defaultDarkTheme variable is added to application_config.js and set to true, this sets the theme to dark by default irrespective of browser settings
     var checkDefaultDarkTheme = function () {
         if (AppConfig.defaultDarkTheme) {
             return os = 'dark';

--- a/www/common/boot2.js
+++ b/www/common/boot2.js
@@ -1,40 +1,51 @@
-(function () {
-try {
-    var isDarkOS = function () {
-        try {
-            return window.matchMedia('(prefers-color-scheme: dark)').matches;
-        } catch (e) { return false; }
-    };
-    var flush = window.CryptPad_flushCache = function () {
-        Object.keys(localStorage).forEach(function (k) {
-            if (k.indexOf('CRYPTPAD_CACHE|') !== 0 && k.indexOf('LESS_CACHE') !== 0) { return; }
-            delete localStorage[k];
-        });
-    };
-    var os = isDarkOS() ? 'dark' : 'light';
-    var key = 'CRYPTPAD_STORE|colortheme';
-    window.CryptPad_theme = localStorage[key] || os;
-    if (!localStorage[key]) {
-        // We're using OS theme, check if we need to change
-        if (os !== localStorage[key+'_default']) {
-            console.warn('New OS theme, flush cache');
-            flush();
-            localStorage[key+'_default'] = os;
-        }
-    }
-    if (window.CryptPad_theme === 'dark') {
-        var s = document.createElement('style');
-        s.innerHTML = 'body { background: black; }';
-        document.body.appendChild(s);
-    }
-} catch (e) { console.error(e); }
-})();
-
-// This is stage 1, it can be changed but you must bump the version of the project.
 define([
-    '/common/requireconfig.js'
-], function (RequireConfig) {
+    '/common/requireconfig.js', 
+    '/customize/application_config.js'
+], function (RequireConfig, AppConfig) {
 
+    var checkDefaultDarkTheme = function () {
+        if (AppConfig.defaultDarkTheme) {
+            return os = 'dark';
+        } else {
+            var isDarkOS = function () {
+                try {
+                    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+                } catch (e) { return false; }
+            };
+            return os = isDarkOS() ? 'dark' : 'light';
+        }
+    }; 
+
+    var os = checkDefaultDarkTheme()
+    
+    try {
+        var flush = window.CryptPad_flushCache = function () {
+            Object.keys(localStorage).forEach(function (k) {
+                if (k.indexOf('CRYPTPAD_CACHE|') !== 0 && k.indexOf('LESS_CACHE') !== 0) { return; }
+                delete localStorage[k];
+            });
+        };
+
+        var key = 'CRYPTPAD_STORE|colortheme';
+        window.CryptPad_theme = localStorage[key] || os;
+        if (!localStorage[key]) {
+            // We're using OS theme, check if we need to change
+            if (os !== localStorage[key+'_default']) {
+                console.warn('New OS theme, flush cache');
+                flush();
+                localStorage[key+'_default'] = os;
+            }
+        }
+        if (window.CryptPad_theme === 'dark') {
+            var s = document.createElement('style');
+            s.innerHTML = 'body { background: black; }';
+            document.body.appendChild(s);
+        }
+    } catch (e) { console.error(e); }
+
+
+
+    // This is stage 1, it can be changed but you must bump the version of the project.
     require.config(RequireConfig());
 
     // most of CryptPad breaks if you don't support isArray


### PR DESCRIPTION
As requested [here](https://github.com/xwiki-labs/cryptpad/issues/759), if an AppConfig.defaultDarkTheme variable is added to application_config.js and set to true, this sets the theme to dark by default irrespective of browser settings. 