### PR TITLE
Hide editor if previewing code read only and it is previewable

### DIFF
--- a/www/code/app-code.less
+++ b/www/code/app-code.less
@@ -108,6 +108,7 @@
         color: @cp_preview-fg;
         max-width: 70ch;
         margin: 1em auto;
+        padding-left: 10px;
 
         .markdown_preformatted-code;
         .markdown_gfm-table();
@@ -126,9 +127,13 @@
     .cp-splitter {
         position: absolute;
         height: 100%;
-        width: 8px;
+        width: 5px;
         top: 0;
         left: 0;
+
+        // stripes to clue that the pain is slidable - not strictly necessary for the change but I like it
+        background-image: linear-gradient(45deg, grey 25%, darkgrey 25%, darkgrey 50%, grey 50%, grey 75%, darkgrey 75%, darkgrey 100%);
+        background-size: 28.28px 28.28px;
 
         cursor: col-resize;
     }

--- a/www/code/app-code.less
+++ b/www/code/app-code.less
@@ -28,6 +28,11 @@
             resize: none;
             flex: 1;
         }
+        &.cp-app-code-hide-code {
+            // to hide the code if it is a previewable file being viewed read only
+            min-width: 0%;
+            width: 0%;
+        }
     }
     .CodeMirror {
         flex: 1;

--- a/www/code/inner.js
+++ b/www/code/inner.js
@@ -461,6 +461,9 @@ define([
             });
         } else {
             CodeMirror.configureTheme(common);
+            
+            // If read only then hide the raw code
+            $('#cp-app-code-container').addClass('cp-app-code-hide-code');
         }
 
         framework.onContentUpdate(function (newContent) {


### PR DESCRIPTION
This is useful when you just want to share the compiled markdown with someone who would be distracted by the raw text.

I also changed the slider styling, this makes it more obvious that you can drag it to adjust the panes.