### PR TITLE
Auto-select document name on edit if it's still the default

### DIFF
--- a/www/common/toolbar.js
+++ b/www/common/toolbar.js
@@ -764,6 +764,10 @@ MessengerUI, Messages, Pages) {
             $input.val(inputVal);
             $input.show();
             $input.focus();
+            if (inputVal === $input.attr('placeholder')) {
+                // Placeholder is the default name, select text to make editing easier
+                $input.select();
+            }
             $pencilIcon.hide();
             $saveIcon.show();
         };


### PR DESCRIPTION
A small convenience to enable clicking a document name and immediately typing the name, if it hasn't been set already.

Since the background colour of the `input` is different to the text that it replaces, it always tricks me into thinking it's selected, so I just start typing. The text then just gets appended to the default name.