### PR TITLE
invert NGINX settings to forbid remote embedding by default

### DIFF
--- a/docs/example.nginx.conf
+++ b/docs/example.nginx.conf
@@ -23,15 +23,12 @@ server {
     set $main_domain "your-main-domain.com";
     set $sandbox_domain "your-sandbox-domain.com";
 
-    # By default CryptPad allows remote domains to embed CryptPad documents in iframes.
-    # This behaviour can be blocked by changing $allowed_origins from "*" to the
-    # sandbox domain, which must be permitted to load content from the main domain
-    # in order for CryptPad to work as expected.
-    #
-    # An example is given below which can be uncommented if you want to block
-    # remote sites from including content from your server
-    set $allowed_origins "*";
-    # set $allowed_origins "https://${sandbox_domain}";
+    # By default CryptPad forbids remote domains from embedding CryptPad documents in iframes.
+    # The sandbox domain must always be permitted in order for the platform to function.
+    # If you wish to enable remote embedding you may change the value below to "*"
+    # as per the commented value.
+    set $allowed_origins "https://${sandbox_domain}";
+    #set $allowed_origins "*";
 
     # CryptPad's dynamic content (websocket traffic and encrypted blobs)
     # can be served over separate domains. Using dedicated domains (or subdomains)


### PR DESCRIPTION
The API server started forbidding remote embedding by default a number of major versions ago, but we didn't update the default value for `$allowed_origins` in the example NGINX config. This patch updates its default match that of the API server.

As per usual, the comment is probably the hard part, so it might be worthwhile to worker on a better/clearer phrasing.