### PR TITLE
This change makes the New button to go on the top of the list. Addresses #752

### DIFF
--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -3478,7 +3478,7 @@ define([
             var isInRoot = currentPath[0] === ROOT;
             var $element = $('<li>', {
                 'class': 'cp-app-drive-element-row cp-app-drive-new-ghost'
-            }).prepend($addIcon.clone()).appendTo($list);
+            }).prepend($addIcon.clone()).prependTo($list);
             $element.append($('<span>', {'class': 'cp-app-drive-element-name'})
                 .text(Messages.fm_newButton));
             $element.click(function () {


### PR DESCRIPTION
The New button in CryptDrive will appear in list view on the top of the list instead of the bottom of it, as shown in Image_1. In grid view, this will place the New icon before of the File names list, as shown in Image_2. 

This is addressing Issue #752. 

<img width="745" alt="Image_1" src="https://user-images.githubusercontent.com/95185329/218880410-2d1172dc-02a6-4ee9-97e7-955e32c97325.png">
<img width="872" alt="Image_2" src="https://user-images.githubusercontent.com/95185329/218880413-6428fbc6-8257-499d-8392-e6e83e4fffa8.png">
