### PR TITLE
[Mathjax Form] Mathjax formatting

### DIFF
--- a/www/common/diffMarked.js
+++ b/www/common/diffMarked.js
@@ -527,6 +527,7 @@ define([
             var el = $el[0];
             if (!el) { return; }
             var code = el.getAttribute("mathjax-source");
+            if (!Mathjax.version) setTimeout(() => { this.render($el), 1000 });
             var svg = Mathjax.tex2svg(code, {display: true});
             if (!svg) { return; }
             svg.innerHTML = svg.innerHTML.replace(/xlink:href/g, "href");


### PR DESCRIPTION
Mathjax formatting doesn't display correctly in Markdown when the page is loaded or reloaded from Forms. 
Because the `plugins.mathjax.render` function is being called before the Mathjax plugin has fully loaded. 
I solved by using the following approach: If `Mathjax.version` is undefined, wait one second and then call the function again.

![Captura de tela de 2023-04-08 00-06-29](https://user-images.githubusercontent.com/34924779/230700883-e1dcb2a1-7653-4984-a3c4-b35c5c706926.png)
