### PR TITLE
Form app unit tests

### DIFF
--- a/www/assert/main.js
+++ b/www/assert/main.js
@@ -16,9 +16,10 @@ define([
     '/common/hyperscript.js',
     '/customize/messages.js',
     '../form/inner.js',
+    '../form/condorcet.js',
     '/bower_components/tweetnacl/nacl-fast.min.js',
     'less!/customize/src/less2/pages/page-assert.less',
-], function ($, Hyperjson, Sortify, Drive, /*Test,*/ Hash, Util, Thumb, Wire, Flat, MediaTag, Block, ApiConfig, Assertions, h, Messages, Form) {
+], function ($, Hyperjson, Sortify, Drive, /*Test,*/ Hash, Util, Thumb, Wire, Flat, MediaTag, Block, ApiConfig, Assertions, h, Messages, Form, Condorcet) {
     window.Hyperjson = Hyperjson;
     window.Sortify = Sortify;
     var Nacl = window.nacl;
@@ -510,11 +511,17 @@ define([
 
     assert(function (cb) {
         var days = Form.getWeekDays();
-      
         var result = days.length === 7; 
       
         cb(result);
     }, "getWeekDays: Checks how many weekdays retrieved");  
+
+    assert(function (cb) {
+        var days = Form.getWeekDays();
+        var result = days.includes('Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'); 
+      
+        cb(result);
+    }, "getWeekDays: Checks all weekdays retrieved");  
 
     assert(function (cb) {
         var array = [0, 0, 1]
@@ -524,23 +531,36 @@ define([
     }, "arrayMax: Checks the max value of an array");  
 
     assert(function (cb) {
+        var array = [20021, 0, -1, 0.9]
+        var result = Form.arrayMax(array) === 20021;
+      
+        cb(result);
+    }, "arrayMax: Checks the max value of an array"); 
+
+    assert(function (cb) {
         var array = [0, 0, 0]
         var result = Form.arrayMax(array) === 0;
       
         cb(result);
     }, "arrayMax: Checks the max value of an array if all values the same");  
 
-    //TO CHECK -- NaN not a valid result type
-    // assert(function (cb) {
-    //     var array = ['example', 'text']
-    //     var result = Form.arrayMax(array) === NaN;
+    assert(function (cb) {
+        var array = ['example', 'text']
+        var result = String(Form.arrayMax(array)) === String(NaN)
       
-    //     cb(result);
-    // }, "arrayMax: Checks that NaN is returned if values are not numerical");  
+        cb(result);
+    }, "arrayMax: Checks that NaN is returned if values are not numerical");  
+
+    assert(function (cb) {
+        var array = []
+        var result = String(Form.arrayMax(array)) === String(-Infinity)
+        //add error catch block in case empty array passed as argument?
+      
+        cb(result);
+    }, "arrayMax: Checks that -Infinity is returned if array is empty");  
 
     assert(function (cb) {
         var object = { uid: "1rrtjll2sl4", v: 1680688800000 }
-
         var result = Form.getOptionValue(object) === 1680688800000
 
         cb(result);
@@ -586,16 +606,26 @@ define([
         cb(result);
     }, "extractValues: Checks if option value array generated with only one value");  
 
+    assert(function (cb) {
+        var values = []
+
+        var result = JSON.stringify(Form.extractValues(values)) === JSON.stringify([])
+        console.log("EMPTY AR", Form.extractValues(values))
+        cb(result);
+    }, "extractValues: Checks if option value array generated with only one value");  
+
     
-    // assert(function (cb) {
-    //     var answers = {"q+3dZT3CJ+XbkWhi5092symcW+IGJZPzd0RShYMEsHE=|35hfju0fsnu":{"msg":{"69rjecmhjb9":",mn,mn,mn,mn,mn","_uid":"35hfju0fsnu","_time":1681202916647,"_hash":"DbnusGXMDX663VM7D21tqQfz4pQIs7BKp6UpRBueoXtchIulIoqftOOWj7PpU6Lx"},"hash":"DbnusGXMDX663VM7D21tqQfz4pQIs7BKp6UpRBueoXtchIulIoqftOOWj7PpU6Lx","time":1681206767511},"SiTGBfCFwlcsLTNvufacxbc9X6mUpIoG9n1GAceMlA4=|66kj6s52omt":{"msg":{"69rjecmhjb9":"kjkjkjlkjlkjlkjlkjlkjlkjlkj","_uid":"66kj6s52omt","_time":1681205388977,"_hash":"TAoVobz7rNK3RSzkTpcaXRa47Eo63P0UvYjpGYSP1plgn8sq8iY1o4TdU4/LrnoE"},"hash":"TAoVobz7rNK3RSzkTpcaXRa47Eo63P0UvYjpGYSP1plgn8sq8iY1o4TdU4/LrnoE","time”:1681202916647},”NeDLoqFcwcKwd6rphOpEQ5X6aSlN9qGsvgi57kWKLA0=|1oq2djufaap":{"msg":{"69rjecmhjb9":"brrrrrrrrrr","_uid":"1oq2djufaap","_time":1681206767511,"_hash":"l/nJS20MK04js5WrPJCyZNF7WTmHXF9fdQXYRT0iY9DalgeetuBKnndKmwVG5kUr"},"hash":"l/nJS20MK04js5WrPJCyZNF7WTmHXF9fdQXYRT0iY9DalgeetuBKnndKmwVG5kUr","time":1681205388977}}}
+    assert(function (cb) {
+        var answers = {"WenuyjXqytwp4RvjOnkqL2mL+Z1OUOGwzKAFqD++2FM=|6ic6tr4cio3":{"msg":{"4cdnfi0j2fa":"answer3","4qt5cp2e5rv":"Option 1","_uid":"6ic6tr4cio3","_time":1681914626141,"_hash":"zjRZuLldOGGDiMDADt+9RHTvEhRFMmllPLRpx0TrAClqvXlp34wOBm2Td/Wzi5Wd"},"hash":"zjRZuLldOGGDiMDADt+9RHTvEhRFMmllPLRpx0TrAClqvXlp34wOBm2Td/Wzi5Wd","time":1681914626141},
+        "3yqquxm647TlFfCj0BlYnWgWLTa+YwvUP3WNBR/1RV0=|129h2op1sb7":{"msg":{"4cdnfi0j2fa":"answer2","4qt5cp2e5rv":"Option 1","_uid":"129h2op1sb7","_time":1681914593908,"_hash":"zAe3Fu+WNsn0vDJypAkMAvhVi2pKNVFICnM07jWHWNNu1TFm5MXFdfUMnL3TdxWx"},"hash":"zAe3Fu+WNsn0vDJypAkMAvhVi2pKNVFICnM07jWHWNNu1TFm5MXFdfUMnL3TdxWx","time":1681914593908},
+        "Si2A3iC2Z4rcghpAPrh6vc/Bish5HZ0RGryqMljJyjo=|fhs3rsq5ef":{"msg":{"4cdnfi0j2fa":"answer1","4qt5cp2e5rv":"Option 2","_uid":"fhs3rsq5ef","_time":1681914418756,"_hash":"LxqKNj8HD3Jp9B8OVnmkPAzolM9H2Fa4TW2KrbwYZoy1PFGrrham9ftuZxesUE0i"},"hash":"LxqKNj8HD3Jp9B8OVnmkPAzolM9H2Fa4TW2KrbwYZoy1PFGrrham9ftuZxesUE0i","time":1681914418756},}
         
-    //     var result = JSON.stringify(Form.getSortedKeys(answers)) === JSON.stringify(['SiTGBfCFwlcsLTNvufacxbc9X6mUpIoG9n1GAceMlA4=|66kj6s52omt','NeDLoqFcwcKwd6rphOpEQ5X6aSlN9qGsvgi57kWKLA0=|1oq2djufaap', 'q+3dZT3CJ+XbkWhi5092symcW+IGJZPzd0RShYMEsHE=|35hfju0fsnu'])
+        var result = JSON.stringify(Form.getSortedKeys(answers)) === JSON.stringify(["Si2A3iC2Z4rcghpAPrh6vc/Bish5HZ0RGryqMljJyjo=|fhs3rsq5ef","3yqquxm647TlFfCj0BlYnWgWLTa+YwvUP3WNBR/1RV0=|129h2op1sb7","WenuyjXqytwp4RvjOnkqL2mL+Z1OUOGwzKAFqD++2FM=|6ic6tr4cio3"])
 
-    //     cb(result);
-    // }, "getSortedKeys: Checks if answer key array generated in correct order");  
+        cb(result);
+    }, "getSortedKeys: Checks if answer key array generated in correct order (by date)");  
 
-    //TO CHECK -- == NOT ===
+ 
     assert(function (cb) {
         var dateToday = new Date(1681202916647)
 
@@ -622,9 +652,22 @@ define([
         cb(result);
     }, "parseAnswers: Checks if answers parsed correctly");  
 
-    // //BLANK
-    // //no answers
-    // //all kinds
+
+    assert(function (cb) {
+        var answers = {"NixYYkVPFCYUBh8LOQ1VchV7lfaTW4vgNiAKq89y+j0=":{"4oril7f8on3":{"msg":{"2":"","6v52hnop75":"","_uid":"4oril7f8on3","_time":1681813029990,"_hash":"Q6NjRGHWbmIIvEJ8RoLcTzfM+d/4NgHnT6xltkjK7Il8v6iIWSyS97gUHVKnRfZb"},"hash":"Q6NjRGHWbmIIvEJ8RoLcTzfM+d/4NgHnT6xltkjK7Il8v6iIWSyS97gUHVKnRfZb","time":1681813029990}},"Sf2e5dvPYQZYOcIhr4jxeO+fDvXiytggDtGx8Uan4mE=":{"2bpmiu5vbqu":{"msg":{"2":"","6v52hnop75":"","_userdata":{"name":"name1"},"_uid":"2bpmiu5vbqu","_time":1681813111981,"_hash":"hVYUczHSRsNr0lNqrqx7AYpV0eyDB2WK0ozVV482DMwdGU0BPLIBUmK6kkYhP71J"},"hash":"hVYUczHSRsNr0lNqrqx7AYpV0eyDB2WK0ozVV482DMwdGU0BPLIBUmK6kkYhP71J","time":1681813111981}}}
+
+        var result = JSON.stringify(Form.parseAnswers(answers)) === JSON.stringify({"NixYYkVPFCYUBh8LOQ1VchV7lfaTW4vgNiAKq89y+j0=|4oril7f8on3":{"msg":{"2":"","6v52hnop75":"","_uid":"4oril7f8on3","_time":1681813029990,"_hash":"Q6NjRGHWbmIIvEJ8RoLcTzfM+d/4NgHnT6xltkjK7Il8v6iIWSyS97gUHVKnRfZb"},"hash":"Q6NjRGHWbmIIvEJ8RoLcTzfM+d/4NgHnT6xltkjK7Il8v6iIWSyS97gUHVKnRfZb","time":1681813029990},"Sf2e5dvPYQZYOcIhr4jxeO+fDvXiytggDtGx8Uan4mE=|2bpmiu5vbqu":{"msg":{"2":"","6v52hnop75":"","_userdata":{"name":"name1"},"_uid":"2bpmiu5vbqu","_time":1681813111981,"_hash":"hVYUczHSRsNr0lNqrqx7AYpV0eyDB2WK0ozVV482DMwdGU0BPLIBUmK6kkYhP71J"},"hash":"hVYUczHSRsNr0lNqrqx7AYpV0eyDB2WK0ozVV482DMwdGU0BPLIBUmK6kkYhP71J","time":1681813111981}})
+
+        cb(result);
+    }, "parseAnswers: Checks if blank answers parsed correctly");  
+
+    assert(function (cb) {
+        var answers = {"NixYYkVPFCYUBh8LOQ1VchV7lfaTW4vgNiAKq89y+j0=":{"4oril7f8on3":{"msg":{"2":"Option 1","6v52hnop75":"text answer1","_uid":"4oril7f8on3","_time":1681813029990,"_hash":"Q6NjRGHWbmIIvEJ8RoLcTzfM+d/4NgHnT6xltkjK7Il8v6iIWSyS97gUHVKnRfZb"},"hash":"Q6NjRGHWbmIIvEJ8RoLcTzfM+d/4NgHnT6xltkjK7Il8v6iIWSyS97gUHVKnRfZb","time":1681813029990}},"Sf2e5dvPYQZYOcIhr4jxeO+fDvXiytggDtGx8Uan4mE=":{"2bpmiu5vbqu":{"msg":{"2":"Option 2","6v52hnop75":"text answer2","_userdata":{"name":""},"_uid":"2bpmiu5vbqu","_time":1681813111981,"_hash":"hVYUczHSRsNr0lNqrqx7AYpV0eyDB2WK0ozVV482DMwdGU0BPLIBUmK6kkYhP71J"},"hash":"hVYUczHSRsNr0lNqrqx7AYpV0eyDB2WK0ozVV482DMwdGU0BPLIBUmK6kkYhP71J","time":1681813111981}}}
+
+        var result = JSON.stringify(Form.parseAnswers(answers)) === JSON.stringify({"NixYYkVPFCYUBh8LOQ1VchV7lfaTW4vgNiAKq89y+j0=|4oril7f8on3":{"msg":{"2":"Option 1","6v52hnop75":"text answer1","_uid":"4oril7f8on3","_time":1681813029990,"_hash":"Q6NjRGHWbmIIvEJ8RoLcTzfM+d/4NgHnT6xltkjK7Il8v6iIWSyS97gUHVKnRfZb"},"hash":"Q6NjRGHWbmIIvEJ8RoLcTzfM+d/4NgHnT6xltkjK7Il8v6iIWSyS97gUHVKnRfZb","time":1681813029990},"Sf2e5dvPYQZYOcIhr4jxeO+fDvXiytggDtGx8Uan4mE=|2bpmiu5vbqu":{"msg":{"2":"Option 2","6v52hnop75":"text answer2","_userdata":{"name":""},"_uid":"2bpmiu5vbqu","_time":1681813111981,"_hash":"hVYUczHSRsNr0lNqrqx7AYpV0eyDB2WK0ozVV482DMwdGU0BPLIBUmK6kkYhP71J"},"hash":"hVYUczHSRsNr0lNqrqx7AYpV0eyDB2WK0ozVV482DMwdGU0BPLIBUmK6kkYhP71J","time":1681813111981}})
+
+        cb(result);
+    }, "parseAnswers: Checks if anonymous answers parsed correctly");  
 
     assert(function (cb) {
         var answers = {"dnD12ORDDrY/tyN84dhBDznuJMxyPbXTk9qDygrqnmg=":{"726f3f4ulmd":{"msg":{"2":"Option 1","7mkcosm2rt0":"answer text","_uid":"726f3f4ulmd","_time":1681300220930,"_hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF"},"hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF","time":1681300220930}},"p6GuFDW8MBFm08qk8wYQtXHdKGhSBsdR5NgphX3dIyA=":{"ofu17vk29q":{"msg":{"2":"Option 2","7mkcosm2rt0":"example text","_uid":"ofu17vk29q","_time":1681300240916,"_hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ"},"hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ","time":1681300240916}},"O6+R4oi9CN2PIK/G9CcvZGWPaOnp+wdPnT4C87XLu0E=":{"7gvtagjf10j":{"msg":{"7mkcosm2rt0":"","_userdata":{"name":"example name"},"_uid":"7gvtagjf10j","_time":1681300260886,"_hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj"},"hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj","time":1681300260886}}}
@@ -635,8 +678,16 @@ define([
     }, "getAnswersLength: Checks if answers length correct");  
 
     assert(function (cb) {
+        var answers = {"dnD12ORDDrY/tyN84dhBDznuJMxyPbXTk9qDygrqnmg=":{"726f3f4ulmd":{"msg":{"2":"","7mkcosm2rt0":"","_uid":"726f3f4ulmd","_time":1681300220930,"_hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF"},"hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF","time":1681300220930}},"p6GuFDW8MBFm08qk8wYQtXHdKGhSBsdR5NgphX3dIyA=":{"ofu17vk29q":{"msg":{"2":"","7mkcosm2rt0":"","_uid":"ofu17vk29q","_time":1681300240916,"_hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ"},"hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ","time":1681300240916}},"O6+R4oi9CN2PIK/G9CcvZGWPaOnp+wdPnT4C87XLu0E=":{"7gvtagjf10j":{"msg":{"7mkcosm2rt0":"","_userdata":{"name":"example name"},"_uid":"7gvtagjf10j","_time":1681300260886,"_hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj"},"hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj","time":1681300260886}}}
+
+        var result = Form.getAnswersLength(answers) === 3;
+
+        cb(result);
+    }, "getAnswersLength: Checks if blank answers length correct");  
+
+    assert(function (cb) {
         var uid = "66gk9ne3plg"
-        var items = [{ uid: "66gk9ne3plg", v: "Item 1" }, { uid: "66gk9ne3plg", v: "Item 1" }]
+        var items = [{ uid: "6v52hnop75", v: "Item 2" }, { uid: "66gk9ne3plg", v: "Item 1" }]
         
         var result = Form.findItem(items, uid) === 'Item 1'
 
@@ -650,27 +701,7 @@ define([
         var result = JSON.stringify(Form.getSections(content)) === JSON.stringify(["3nqrkethqre"])
 
         cb(result);
-    }, "getSections: Checks if sections question type correctly identified (by uid)");  
-
-    assert(function (cb) {
-        var content = {"answers":{"anonymous":true,"channel":"f0c618aafe7071f8c239834793643d66","publicKey":"82gx8xzoV6bgHBQ1zoic57b2cjgxZ9zO2V67c2486ng=","validateKey":"in4+E1sKdZ+MHayQ5O2gJdMqi4Tvmk35/z/1HEqTr4M=","version":2},"form":{"1q086i8iuv0":{"opts":{"type":"text"},"type":"input"},"2de53antgns":{"opts":{"type":"text"},"type":"input"},"3nqrkethqre":{"opts":{"questions":["2de53antgns"],"when":[]},"type":"section"},"489ghit6aa6":{"opts":{"type":"text"},"type":"input"},"5l43527l18c":{"opts":{"maxLength":1000},"type":"textarea"},"5satfltfm3u":{"opts":{"type":"text"},"type":"input"}},"order":["5l43527l18c","489ghit6aa6","1q086i8iuv0","5satfltfm3u","3nqrkethqre"],"version":1}
-
-        var result = JSON.stringify(Form.getFullOrder(content)) === JSON.stringify([ "5l43527l18c", "489ghit6aa6", "1q086i8iuv0", "5satfltfm3u", "3nqrkethqre", "2de53antgns" ])
-
-        cb(result);
-    }, "getFullOrder: Checks if array of answer uids generated in correct order");  
-
-    assert(function (cb) {
-        var answers = {"PIZkFh+x41UdYNXEEAAhzNRG2juhlH6bbvX9xw+KO0c=|2fkkqujbog4":{"msg":{"7bnj9a8okpn":{"values":{"Option 1":"1","Option 2":"0","Option 3":"0"}},"_uid":"2fkkqujbog4","_time":1681411078436,"_hash":"FbIr34E1A88dX9QXflyxwa/uLIKmucq0XYvuRQyNxfoJSN7fO4oh/KxxVekDXqAk"},"hash":"FbIr34E1A88dX9QXflyxwa/uLIKmucq0XYvuRQyNxfoJSN7fO4oh/KxxVekDXqAk","time":1681411078436}}
-        
-        var uid = "7bnj9a8okpn"
-
-        var filterCurve = false
-
-        var result = JSON.stringify(Form.getBlockAnswers(answers, uid, filterCurve)) === JSON.stringify([{"curve":"PIZkFh+x41UdYNXEEAAhzNRG2juhlH6bbvX9xw+KO0c=","results":{"values":{"Option 1":"1","Option 2":"0","Option 3":"0"}},"time":1681411078436}])
-
-        cb(result);
-    }, "getBlockAnswers: ");  
+    }, "getSections: Checks if section question type correctly identified (by uid)");  
 
     assert(function (cb) {
         var content = {"answers":{"anonymous":true,"channel":"dd879143bd4a49fd7e68f6c5109e4d9f","publicKey":"Ja4U/ESMGx/BjTTChbAZD+SFG0P+93o3F4XW6CJR0DA=","validateKey":"swNQf0LqJFWThBSE+iw8VryY2xId+QVcbn9XFeLNfXU=","version":2},"form":{"3e81recgc5g":{"opts":{"type":"text"},"type":"input"},"60tij442l02":{"opts":{"questions":["3e81recgc5g"],"when":[]},"type":"section"},"6bbmju7i65i":{"opts":{"type":"text"},"type":"input"}},"order":["6bbmju7i65i","60tij442l02"],"version":1}
@@ -678,33 +709,24 @@ define([
         var result = JSON.stringify(Form.getSections(content)) === JSON.stringify([ "60tij442l02" ])
 
         cb(result);
-    }, "getSections: ");  
+    }, "getSections: Checks if section question type correctly identified (by uid)");  
 
-    //CAN'T MOCK 'APP'
     assert(function (cb) {
-        // var answers = {"dnD12ORDDrY/tyN84dhBDznuJMxyPbXTk9qDygrqnmg=":{"726f3f4ulmd":{"msg":{"2":"Option 1","7mkcosm2rt0":"answer text","_uid":"726f3f4ulmd","_time":1681300220930,"_hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF"},"hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF","time":1681300220930}},"p6GuFDW8MBFm08qk8wYQtXHdKGhSBsdR5NgphX3dIyA=":{"ofu17vk29q":{"msg":{"2":"Option 2","7mkcosm2rt0":"example text","_uid":"ofu17vk29q","_time":1681300240916,"_hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ"},"hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ","time":1681300240916}},"O6+R4oi9CN2PIK/G9CcvZGWPaOnp+wdPnT4C87XLu0E=":{"7gvtagjf10j":{"msg":{"7mkcosm2rt0":"","_userdata":{"name":"example name"},"_uid":"7gvtagjf10j","_time":1681300260886,"_hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj"},"hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj","time":1681300260886}}}
-        // var APP = {};
-        APP.formBlocks = [{"tag":{"jQuery360028827848464003571":{"events":{"keypress":[{"type":"keypress","origType":"keypress","guid":55,"namespace":""}],"change":[{"type":"change","origType":"change","guid":55,"namespace":""}]}}},"uid":"298095t8h92"},{"tag":{"jQuery360028827848464003571":{"events":{"keypress":[{"type":"keypress","origType":"keypress","guid":56,"namespace":""}],"change":[{"type":"change","origType":"change","guid":56,"namespace":""}]}}},"uid":"69rjecmhjb9"}]
-        console.log("YOOHOO", JSON.stringify(Form.getFormResults()))
-        var result = JSON.stringify(Form.getFormResults()) 
-        console.log("YUYIUYUY", result)
-        // === JSON.stringify({ "298095t8h92": "answer1", "69rjecmhjb9": "answer2" })
+        var content = {"answers":{"anonymous":true,"channel":"f0c618aafe7071f8c239834793643d66","publicKey":"82gx8xzoV6bgHBQ1zoic57b2cjgxZ9zO2V67c2486ng=","validateKey":"in4+E1sKdZ+MHayQ5O2gJdMqi4Tvmk35/z/1HEqTr4M=","version":2},"form":{"1q086i8iuv0":{"opts":{"type":"text"},"type":"input"},"2de53antgns":{"opts":{"type":"text"},"type":"input"},"489ghit6aa6":{"opts":{"type":"text"},"type":"input"},"5l43527l18c":{"opts":{"maxLength":1000},"type":"textarea"},"5satfltfm3u":{"opts":{"type":"text"},"type":"input"}},"order":["5l43527l18c","489ghit6aa6","1q086i8iuv0","5satfltfm3u","3nqrkethqre"],"version":1}
+
+        var result = JSON.stringify(Form.getSections(content)) === JSON.stringify([])
 
         cb(result);
-    }, "getFormResults: ");  
+    }, "getSections: Checks if lack of section question type correctly identified");  
 
+    assert(function (cb) {
+        var content = {"answers":{"anonymous":true,"channel":"f0c618aafe7071f8c239834793643d66","publicKey":"82gx8xzoV6bgHBQ1zoic57b2cjgxZ9zO2V67c2486ng=","validateKey":"in4+E1sKdZ+MHayQ5O2gJdMqi4Tvmk35/z/1HEqTr4M=","version":2},"form":{"1q086i8iuv0":{"opts":{"type":"text"},"type":"input"},"2de53antgns":{"opts":{"type":"text"},"type":"input"},"3nqrkethqre":{"opts":{"questions":["2de53antgns"],"when":[]},"type":"section"},"489ghit6aa6":{"opts":{"type":"text"},"type":"input"},"5l43527l18c":{"opts":{"maxLength":1000},"type":"textarea"},"5satfltfm3u":{"opts":{"type":"text"},"type":"input"}},"order":["5l43527l18c","489ghit6aa6","1q086i8iuv0","5satfltfm3u","3nqrkethqre"],"version":1}
 
-    // assert(function (cb) {
-    //     var content = {"answers":{"anonymous":true,"channel":"dd879143bd4a49fd7e68f6c5109e4d9f","publicKey":"Ja4U/ESMGx/BjTTChbAZD+SFG0P+93o3F4XW6CJR0DA=","validateKey":"swNQf0LqJFWThBSE+iw8VryY2xId+QVcbn9XFeLNfXU=","version":2},"form":{"3e81recgc5g":{"opts":{"type":"text"},"type":"input"},"60tij442l02":{"opts":{"questions":["3e81recgc5g"],"when":[]},"type":"section"},"6bbmju7i65i":{"opts":{"type":"text"},"type":"input"}},"order":["6bbmju7i65i","60tij442l02"],"version":1}
-        
-    //     var uid = "6bbmju7i65i"
+        var result = JSON.stringify(Form.getFullOrder(content)) === JSON.stringify([ "5l43527l18c", "489ghit6aa6", "1q086i8iuv0", "5satfltfm3u", "3nqrkethqre", "2de53antgns" ])
 
-    //     var result = JSON.stringify(Form.getSectionFromQ(content, uid)) 
-    //     // === JSON.stringify({"arr":["76nff13m2m2","6bbmju7i65i","60tij442l02"],"idx":0})
-
-    //     cb(result);
-    // }, "getSectionFromQ: ");  
-
+        cb(result);
+    }, "getFullOrder: Checks if array of answer uids generated in correct order (by date)"); 
+    
     assert(function (cb) {
         var content = {"answers":{"anonymous":true,"channel":"dd879143bd4a49fd7e68f6c5109e4d9f","publicKey":"Ja4U/ESMGx/BjTTChbAZD+SFG0P+93o3F4XW6CJR0DA=","validateKey":"swNQf0LqJFWThBSE+iw8VryY2xId+QVcbn9XFeLNfXU=","version":2},"form":{"3e81recgc5g":{"opts":{"type":"text"},"type":"input"},"53g43utbomt":{"opts":{"type":"text"},"type":"input"},"60tij442l02":{"opts":{"questions":["3e81recgc5g"],"when":[]},"type":"section"},"78uh4r9n10u":{"opts":{"values":[{"uid":"384h23hpkcm","v":"Option 1"},{"uid":"3nnb01frfvl","v":"Option 2"}]},"type":"radio"},"3s5hqske4pc":{"opts":{"type":"text"},"type":"input"}},"order":["60tij442l02","78uh4r9n10u","53g43utbomt","3s5hqske4pc"],"version":1}
         
@@ -715,34 +737,80 @@ define([
         var result = JSON.stringify(content.order) === JSON.stringify(["78uh4r9n10u", "53g43utbomt", "3s5hqske4pc"])
 
         cb(result);
-    }, "removeQuestion: ");  
+    }, "removeQuestion: Checks if correct answer removed");  
 
-    // assert(function (cb) {
-    //     APP.formBlocks = [{"tag":{"jQuery360028827848464003571":{"events":{"keypress":[{"type":"keypress","origType":"keypress","guid":55,"namespace":""}],"change":[{"type":"change","origType":"change","guid":55,"namespace":""}]}}},"uid":"298095t8h92"},{"tag":{"jQuery360028827848464003571":{"events":{"keypress":[{"type":"keypress","origType":"keypress","guid":56,"namespace":""}],"change":[{"type":"change","origType":"change","guid":56,"namespace":""}]}}},"uid":"69rjecmhjb9"}]
-    //     var block = {"opts":{"questions":["3e81recgc5g"],"when":[[{"is":1,"q":"30uco1e435n","uid":"4vvq79pi7s6","v":"Option 1"}]]},"type":"section"}
-    //     // var answers = {"dnD12ORDDrY/tyN84dhBDznuJMxyPbXTk9qDygrqnmg=":{"726f3f4ulmd":{"msg":{"2":"Option 1","7mkcosm2rt0":"answer text","_uid":"726f3f4ulmd","_time":1681300220930,"_hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF"},"hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF","time":1681300220930}},"p6GuFDW8MBFm08qk8wYQtXHdKGhSBsdR5NgphX3dIyA=":{"ofu17vk29q":{"msg":{"2":"Option 2","7mkcosm2rt0":"example text","_uid":"ofu17vk29q","_time":1681300240916,"_hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ"},"hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ","time":1681300240916}},"O6+R4oi9CN2PIK/G9CcvZGWPaOnp+wdPnT4C87XLu0E=":{"7gvtagjf10j":{"msg":{"7mkcosm2rt0":"","_userdata":{"name":"example name"},"_uid":"7gvtagjf10j","_time":1681300260886,"_hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj"},"hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj","time":1681300260886}}}
-    //     var result = JSON.stringify(Form.checkCondition(block)) 
-    //     console.log("WOOOO", result)
-    //     // === true
+    assert(function (cb) {
+        APP.formBlocks = [{"tag":{},"uid":"24g47h86dse"},{"tag":{"jQuery36000305062174891187481":{"events":{"keypress":[{"type":"keypress","origType":"keypress","guid":57,"namespace":""}],"change":[{"type":"change","origType":"change","guid":57,"namespace":""}]}}},"uid":"10uqm9r35h9"}]
+        var block = {"opts":{"questions":["10uqm9r35h9"],"when":[[{"is":1,"q":"24g47h86dse","uid":"7kiq9598am8","v":"Option 1"}]]},"type":"section"}
+        var result = Form.checkCondition(block) === false
 
-    //     cb(result);
-    // }, "checkCondition: ");  
+        cb(result);
+    }, "checkCondition: Checks if conditional section visible -- condition not fulfilled (radio)");
 
-    // assert(function (cb) {
-    //     answers = {"HVfRpDskx2w7DkSGoHXj+naZUE8/sD3vOfch2uLjEXE=":{"tpsubv6rpe":{"msg":{"_uid":"tpsubv6rpe","_time":1681156327353,"_hash":"FvPNwKf6Y3bIvZq/bqR5F81NbVi/uQJLGqvKmpwIlhSmX5taTuNYFTbJNgHEHzkt"},"hash":"FvPNwKf6Y3bIvZq/bqR5F81NbVi/uQJLGqvKmpwIlhSmX5taTuNYFTbJNgHEHzkt","time":1681156327353}}, "HVfRpDskx2w7DkSGoHXj+naZUE8/sD3vOfch2uLjEXE=":{"tpsubv6rpe":{"msg":{"_uid":"tpsubv6rpe","_time":1681156327353,"_hash":"FvPNwKf6Y3bIvZq/bqR5F81NbVi/uQJLGqvKmpwIlhSmX5taTuNYFTbJNgHEHzkt"},"hash":"FvPNwKf6Y3bIvZq/bqR5F81NbVi/uQJLGqvKmpwIlhSmX5taTuNYFTbJNgHEHzkt","time":1681156327353}}}
-    //     uid = '5c3p0rook1f'
-    //     form = {}
-    //     opts = {"values":[{"uid":"4ndmfa2gl7v","v":"Option 1"},{"uid":"26pd96i9v59","v":"Option 2"}]}
+    assert(function (cb) {
+        APP.formBlocks = [{"tag":{"jQuery360026175703682165851":{"events":{"keypress":[{"type":"keypress","origType":"keypress","guid":62,"namespace":""}],"change":[{"type":"change","origType":"change","guid":62,"namespace":""}]}}},"uid":"10uqm9r35h9"}]
+        var block = {"opts":{"questions":["10uqm9r35h9"],"when":[]},"type":"section"}
+        var result = Form.checkCondition(block) === true
 
-    //     var result = Form.renderResults().show().renderResults()
-    //     console.log(result)
-    //     console.log('jkbjbjbjb')
-    //     // var days = Form.renderResults.show.showCondorcet.calculateCondorcet()
-    //     // result = 'kj';
+        cb(result);
+    }, "checkCondition: Checks if conditional section visible -- condition not fulfilled (no condition question present)");
+
+    assert(function (cb) {
+        APP.formBlocks = [{"tag":{},"uid":"h0h248nrpk"},{"tag":{"jQuery360047141651260228671":{"events":{"keypress":[{"type":"keypress","origType":"keypress","guid":59,"namespace":""}],"change":[{"type":"change","origType":"change","guid":59,"namespace":""}]}}},"uid":"10uqm9r35h9"}]
+        var block = {"opts":{"questions":["10uqm9r35h9"],"when":[[{"is":1,"q":"h0h248nrpk","uid":"4ir5d5er545","v":"Option 1"}],[{"is":1,"q":"h0h248nrpk","uid":"1ggrinpholq","v":"Option 2"}]]},"type":"section"}
+        var result = Form.checkCondition(block) === false
+
+        cb(result);
+    }, "checkCondition: Checks if conditional section hidden -- multiple (OR) conditions fulfilled (checkbox)");  
+
+    assert(function (cb) {
+        var answers = {"PIZkFh+x41UdYNXEEAAhzNRG2juhlH6bbvX9xw+KO0c=|2fkkqujbog4":{"msg":{"7bnj9a8okpn":{"values":{"Option 1":"1","Option 2":"0","Option 3":"0"}},"_uid":"2fkkqujbog4","_time":1681411078436,"_hash":"FbIr34E1A88dX9QXflyxwa/uLIKmucq0XYvuRQyNxfoJSN7fO4oh/KxxVekDXqAk"},"hash":"FbIr34E1A88dX9QXflyxwa/uLIKmucq0XYvuRQyNxfoJSN7fO4oh/KxxVekDXqAk","time":1681411078436}}
+        var uid = "7bnj9a8okpn"
+        var result = JSON.stringify(Form.getBlockAnswers(answers, uid)) === JSON.stringify([{"curve":"PIZkFh+x41UdYNXEEAAhzNRG2juhlH6bbvX9xw+KO0c=","results":{"values":{"Option 1":"1","Option 2":"0","Option 3":"0"}},"time":1681411078436}])
+
+        cb(result);
+    }, "getBlockAnswers: Check if block answers parsed correctly (anonymous user)");  
+
+    assert(function (cb) {
+        var answers = {"m/512rQ+TIOyLPmmlU2vQmdlrvAUw+aTVC5Jqu8JRWs=|1ggkp31dnnm":{"msg":{"6ep01jd30on":{"values":{"Option 1":"1","Option 2":"0","Option 3":"0"}},"_userdata":{"name":"maria","notifications":"07ea0832a1dbe2d4b1f8aa4fa943461c","curvePublic":"m/512rQ+TIOyLPmmlU2vQmdlrvAUw+aTVC5Jqu8JRWs=","profile":"/2/profile/view/6INXtxenl5uTvnf6Z7jYro8laeZLmq2qPGgNx+fZe+c/"},"_proof":{"key":"ezXdh5z9QEA0kiG32EyxL6QOVqNj2bsOuIMzF9hBoEM=","proof":"zDRfpkb2yWwCj/Gm0P58195/JwsxAdtbhNKilDPmQ0INYRPORAZokeWK8NrkNXXyXfYvnnOiL6VtNOHlHOmnkrjJMFqCGgc4"},"_uid":"1ggkp31dnnm","_time":1682017859867,"_hash":"AYbmLIObWTXlebjUZ3OPcrbjaMdwve3BIicFKbzt0ThfKFHR8WIoV29rv8m69J30"},"hash":"AYbmLIObWTXlebjUZ3OPcrbjaMdwve3BIicFKbzt0ThfKFHR8WIoV29rv8m69J30","time":1682017859867}}
+        var uid = "6ep01jd30on"
+        var editable = true
+        var filterCurve = "m/512rQ+TIOyLPmmlU2vQmdlrvAUw+aTVC5Jqu8JRWs="
+
+        var result = JSON.stringify(Form.getBlockAnswers(answers, uid, !editable && filterCurve)) === JSON.stringify([{"curve":"m/512rQ+TIOyLPmmlU2vQmdlrvAUw+aTVC5Jqu8JRWs=","user":{"name":"maria","notifications":"07ea0832a1dbe2d4b1f8aa4fa943461c","curvePublic":"m/512rQ+TIOyLPmmlU2vQmdlrvAUw+aTVC5Jqu8JRWs=","profile":"/2/profile/view/6INXtxenl5uTvnf6Z7jYro8laeZLmq2qPGgNx+fZe+c/"},"results":{"values":{"Option 1":"1","Option 2":"0","Option 3":"0"}},"time":1682017859867}])
+
+        cb(result);
+    }, "getBlockAnswers: Check if block answers parsed correctly (registered user)");  
+
+    assert(function (cb) {
+        var content = {"answers":{"anonymous":true,"channel":"8d5fa589851278caf1dde96573f3217e","publicKey":"rh1PZ5aCUhc3qe9w7OUMjLMvpNVi2Tz7b3CUV2DOnTA=","validateKey":"d73YpYxsGiuOsELJCzc1BveZhZq+6tb3xaq89ldfV5A=","version":2},"form":{"5tk7ip4n1qp":{"opts":{"type":"text"},"type":"input"},"69hrg9rnvut":{"opts":{"max":3,"required":true,"values":[{"uid":"1dgo4l7iqgq","v":"Option 1"},{"uid":"26t62c0jclc","v":"Option 2"},{"uid":"7dd8di8tmel","v":"Option 3"}]},"type":"checkbox"},"7vhuq03d8ps":{"opts":{"questions":["5tk7ip4n1qp"],"when":[[{"is":1,"q":"69hrg9rnvut","uid":"7bl8lt9840o","v":"Option 1"}]]},"type":"section"}},"order":["69hrg9rnvut","7vhuq03d8ps"],"version":1}
+        var uid = "69hrg9rnvut"
+        var result = JSON.stringify(Form.getSectionFromQ(content, uid)) === JSON.stringify({"arr":["69hrg9rnvut","7vhuq03d8ps"],"idx":0})
+
+        cb(result);
+    }, "getSectionFromQ: ");  
+
+    assert(function (cb) {
+        var content = {"answers":{"anonymous":true,"channel":"8d5fa589851278caf1dde96573f3217e","publicKey":"rh1PZ5aCUhc3qe9w7OUMjLMvpNVi2Tz7b3CUV2DOnTA=","validateKey":"d73YpYxsGiuOsELJCzc1BveZhZq+6tb3xaq89ldfV5A=","version":2},"form":{"5tk7ip4n1qp":{"opts":{"type":"text"},"type":"input"},"69hrg9rnvut":{"opts":{"max":3,"required":true,"values":[{"uid":"1dgo4l7iqgq","v":"Option 1"},{"uid":"26t62c0jclc","v":"Option 2"},{"uid":"7dd8di8tmel","v":"Option 3"}]},"q":"question2","type":"checkbox"},"6r9qdlr0u2":{"opts":{"values":[{"uid":"16macuje6iq","v":"Option 1"},{"uid":"4hpacdfnvid","v":"Option 2"}]},"q":"question1","type":"radio"},"7vhuq03d8ps":{"opts":{"questions":["5tk7ip4n1qp"],"when":[[{"is":1,"q":"69hrg9rnvut","uid":"7bl8lt9840o","v":"Option 1"}],[{"is":1,"q":"6r9qdlr0u2","uid":"7icugfhfi2d","v":"Option 2"}]]},"type":"section"}},"order":["6r9qdlr0u2","69hrg9rnvut","7vhuq03d8ps"],"version":1}
         
-      
-    //     cb(result);
-    // }, "Condorcet winner");  
+        var uid = "69hrg9rnvut"
+
+        var result = JSON.stringify(Form.getSectionFromQ(content, uid)) === JSON.stringify({"arr":["6r9qdlr0u2","69hrg9rnvut","7vhuq03d8ps"],"idx":1})
+
+        cb(result);
+    }, "getSectionFromQ: ");  
+
+    assert(function (cb) {
+        var optionArray = []
+        var listOfLists = []
+        var _answers
+        var uid
+
+
+        var result = Condorcet.pickMethod(optionArray, listOfLists, _answers, uid)
+
+        cb(result);
+    }, "getSectionFromQ: ");  
 
 
     ///

--- a/www/assert/main.js
+++ b/www/assert/main.js
@@ -20,10 +20,13 @@ define([
     '/bower_components/tweetnacl/nacl-fast.min.js',
     'less!/customize/src/less2/pages/page-assert.less',
 ], function ($, Hyperjson, Sortify, Drive, /*Test,*/ Hash, Util, Thumb, Wire, Flat, MediaTag, Block, ApiConfig, Assertions, h, Messages, Form, Condorcet) {
+    
+    // NOTE: This page will only run correctly if the Framework.create block at the bottom of '../form/inner.js' is commented out.
+    
     window.Hyperjson = Hyperjson;
     window.Sortify = Sortify;
     var Nacl = window.nacl;
-
+    
     var assert = Assertions();
 
     var HJSON_list = [

--- a/www/assert/main.js
+++ b/www/assert/main.js
@@ -511,6 +511,7 @@ define([
 
     assert(function (cb) {
         var days = Form.getWeekDays();
+
         var result = days.length === 7; 
       
         cb(result);
@@ -518,6 +519,7 @@ define([
 
     assert(function (cb) {
         var days = Form.getWeekDays();
+
         var result = days.includes('Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'); 
       
         cb(result);
@@ -525,6 +527,7 @@ define([
 
     assert(function (cb) {
         var array = [0, 0, 1]
+
         var result = Form.arrayMax(array) === 1;
       
         cb(result);
@@ -532,6 +535,7 @@ define([
 
     assert(function (cb) {
         var array = [20021, 0, -1, 0.9]
+
         var result = Form.arrayMax(array) === 20021;
       
         cb(result);
@@ -539,6 +543,7 @@ define([
 
     assert(function (cb) {
         var array = [0, 0, 0]
+
         var result = Form.arrayMax(array) === 0;
       
         cb(result);
@@ -546,6 +551,7 @@ define([
 
     assert(function (cb) {
         var array = ['example', 'text']
+
         var result = String(Form.arrayMax(array)) === String(NaN)
       
         cb(result);
@@ -553,6 +559,7 @@ define([
 
     assert(function (cb) {
         var array = []
+
         var result = String(Form.arrayMax(array)) === String(-Infinity)
         //add error catch block in case empty array passed as argument?
       
@@ -561,6 +568,7 @@ define([
 
     assert(function (cb) {
         var object = { uid: "1rrtjll2sl4", v: 1680688800000 }
+
         var result = Form.getOptionValue(object) === 1680688800000
 
         cb(result);
@@ -610,7 +618,7 @@ define([
         var values = []
 
         var result = JSON.stringify(Form.extractValues(values)) === JSON.stringify([])
-        console.log("EMPTY AR", Form.extractValues(values))
+
         cb(result);
     }, "extractValues: Checks if option value array generated with only one value");  
 
@@ -729,9 +737,7 @@ define([
     
     assert(function (cb) {
         var content = {"answers":{"anonymous":true,"channel":"dd879143bd4a49fd7e68f6c5109e4d9f","publicKey":"Ja4U/ESMGx/BjTTChbAZD+SFG0P+93o3F4XW6CJR0DA=","validateKey":"swNQf0LqJFWThBSE+iw8VryY2xId+QVcbn9XFeLNfXU=","version":2},"form":{"3e81recgc5g":{"opts":{"type":"text"},"type":"input"},"53g43utbomt":{"opts":{"type":"text"},"type":"input"},"60tij442l02":{"opts":{"questions":["3e81recgc5g"],"when":[]},"type":"section"},"78uh4r9n10u":{"opts":{"values":[{"uid":"384h23hpkcm","v":"Option 1"},{"uid":"3nnb01frfvl","v":"Option 2"}]},"type":"radio"},"3s5hqske4pc":{"opts":{"type":"text"},"type":"input"}},"order":["60tij442l02","78uh4r9n10u","53g43utbomt","3s5hqske4pc"],"version":1}
-        
         var uid = "60tij442l02"
-
         Form.removeQuestion(content, uid) 
 
         var result = JSON.stringify(content.order) === JSON.stringify(["78uh4r9n10u", "53g43utbomt", "3s5hqske4pc"])
@@ -742,6 +748,7 @@ define([
     assert(function (cb) {
         APP.formBlocks = [{"tag":{},"uid":"24g47h86dse"},{"tag":{"jQuery36000305062174891187481":{"events":{"keypress":[{"type":"keypress","origType":"keypress","guid":57,"namespace":""}],"change":[{"type":"change","origType":"change","guid":57,"namespace":""}]}}},"uid":"10uqm9r35h9"}]
         var block = {"opts":{"questions":["10uqm9r35h9"],"when":[[{"is":1,"q":"24g47h86dse","uid":"7kiq9598am8","v":"Option 1"}]]},"type":"section"}
+        
         var result = Form.checkCondition(block) === false
 
         cb(result);
@@ -750,6 +757,7 @@ define([
     assert(function (cb) {
         APP.formBlocks = [{"tag":{"jQuery360026175703682165851":{"events":{"keypress":[{"type":"keypress","origType":"keypress","guid":62,"namespace":""}],"change":[{"type":"change","origType":"change","guid":62,"namespace":""}]}}},"uid":"10uqm9r35h9"}]
         var block = {"opts":{"questions":["10uqm9r35h9"],"when":[]},"type":"section"}
+        
         var result = Form.checkCondition(block) === true
 
         cb(result);
@@ -758,6 +766,7 @@ define([
     assert(function (cb) {
         APP.formBlocks = [{"tag":{},"uid":"h0h248nrpk"},{"tag":{"jQuery360047141651260228671":{"events":{"keypress":[{"type":"keypress","origType":"keypress","guid":59,"namespace":""}],"change":[{"type":"change","origType":"change","guid":59,"namespace":""}]}}},"uid":"10uqm9r35h9"}]
         var block = {"opts":{"questions":["10uqm9r35h9"],"when":[[{"is":1,"q":"h0h248nrpk","uid":"4ir5d5er545","v":"Option 1"}],[{"is":1,"q":"h0h248nrpk","uid":"1ggrinpholq","v":"Option 2"}]]},"type":"section"}
+        
         var result = Form.checkCondition(block) === false
 
         cb(result);
@@ -785,46 +794,336 @@ define([
     assert(function (cb) {
         var content = {"answers":{"anonymous":true,"channel":"8d5fa589851278caf1dde96573f3217e","publicKey":"rh1PZ5aCUhc3qe9w7OUMjLMvpNVi2Tz7b3CUV2DOnTA=","validateKey":"d73YpYxsGiuOsELJCzc1BveZhZq+6tb3xaq89ldfV5A=","version":2},"form":{"5tk7ip4n1qp":{"opts":{"type":"text"},"type":"input"},"69hrg9rnvut":{"opts":{"max":3,"required":true,"values":[{"uid":"1dgo4l7iqgq","v":"Option 1"},{"uid":"26t62c0jclc","v":"Option 2"},{"uid":"7dd8di8tmel","v":"Option 3"}]},"type":"checkbox"},"7vhuq03d8ps":{"opts":{"questions":["5tk7ip4n1qp"],"when":[[{"is":1,"q":"69hrg9rnvut","uid":"7bl8lt9840o","v":"Option 1"}]]},"type":"section"}},"order":["69hrg9rnvut","7vhuq03d8ps"],"version":1}
         var uid = "69hrg9rnvut"
+
         var result = JSON.stringify(Form.getSectionFromQ(content, uid)) === JSON.stringify({"arr":["69hrg9rnvut","7vhuq03d8ps"],"idx":0})
 
         cb(result);
-    }, "getSectionFromQ: ");  
+    }, "getSectionFromQ: Check if correct uid array generated when conditional section present (one conditional question)");  
 
     assert(function (cb) {
         var content = {"answers":{"anonymous":true,"channel":"8d5fa589851278caf1dde96573f3217e","publicKey":"rh1PZ5aCUhc3qe9w7OUMjLMvpNVi2Tz7b3CUV2DOnTA=","validateKey":"d73YpYxsGiuOsELJCzc1BveZhZq+6tb3xaq89ldfV5A=","version":2},"form":{"5tk7ip4n1qp":{"opts":{"type":"text"},"type":"input"},"69hrg9rnvut":{"opts":{"max":3,"required":true,"values":[{"uid":"1dgo4l7iqgq","v":"Option 1"},{"uid":"26t62c0jclc","v":"Option 2"},{"uid":"7dd8di8tmel","v":"Option 3"}]},"q":"question2","type":"checkbox"},"6r9qdlr0u2":{"opts":{"values":[{"uid":"16macuje6iq","v":"Option 1"},{"uid":"4hpacdfnvid","v":"Option 2"}]},"q":"question1","type":"radio"},"7vhuq03d8ps":{"opts":{"questions":["5tk7ip4n1qp"],"when":[[{"is":1,"q":"69hrg9rnvut","uid":"7bl8lt9840o","v":"Option 1"}],[{"is":1,"q":"6r9qdlr0u2","uid":"7icugfhfi2d","v":"Option 2"}]]},"type":"section"}},"order":["6r9qdlr0u2","69hrg9rnvut","7vhuq03d8ps"],"version":1}
-        
         var uid = "69hrg9rnvut"
 
         var result = JSON.stringify(Form.getSectionFromQ(content, uid)) === JSON.stringify({"arr":["6r9qdlr0u2","69hrg9rnvut","7vhuq03d8ps"],"idx":1})
 
         cb(result);
-    }, "getSectionFromQ: ");  
+    }, "getSectionFromQ: Check if correct uid array generated when conditional section present (two conditional questions)");  
 
     assert(function (cb) {
-        var _answers
-        var opts
-        var uid
-        var form
-        var optionArray = []
-        var listOfLists = []
+        var _answers = {"vy9HAs3lHjjdD6dob8azENP7J8F52/GfTdBGZP89LVo=|6ge8ff4tlob":{"msg":{"5nlo2d3vik2":["H","I","J","K"],"_uid":"6ge8ff4tlob","_time":1682023994086,"_hash":"vSFODg+ERjSNzluFBkTtNFWKwRX4VyNLaIoWHGdX/mdwEAJhYec37ezQ1NrSobTJ"},"hash":"vSFODg+ERjSNzluFBkTtNFWKwRX4VyNLaIoWHGdX/mdwEAJhYec37ezQ1NrSobTJ","time":1682023994086},"ojccyFYZAagrgbl2SeYK6flY3s6k49GLRC+95uE6vmU=|55q1cfmol3":{"msg":{"5nlo2d3vik2":["H","I","J","K"],"_uid":"55q1cfmol3","_time":1682024029120,"_hash":"mNMXSsj7+oQ41CUwmBDEkX5NItqRmhErFY6PynjF1n1qhdc13wCxlcs7geC3D9TR"},"hash":"mNMXSsj7+oQ41CUwmBDEkX5NItqRmhErFY6PynjF1n1qhdc13wCxlcs7geC3D9TR","time":1682024029120},"tzhcg6al6/bSBlusJsbMeULEr57UiUw2J3pgJcYFzi8=|7fr3t26hgpd":{"msg":{"5nlo2d3vik2":["H","I","J","K"],"_uid":"7fr3t26hgpd","_time":1682024076603,"_hash":"imVXZLoCT65lkuDh57kZ3cdr16/+d78Dx6R3Fu/ObmRkvdsBoc2t/j4w48Pcz28w"},"hash":"imVXZLoCT65lkuDh57kZ3cdr16/+d78Dx6R3Fu/ObmRkvdsBoc2t/j4w48Pcz28w","time":1682024076603}}
+        var opts = {"values":[{"uid":"2vvgb1hudfb","v":"H"},{"uid":"1n3scu8at0d","v":"I"},{"uid":"6o1eie3pr73","v":"J"},{"uid":"77hl1brl9ot","v":"K"}]}
+        var uid = "5nlo2d3vik2"
+        var form = {"5nlo2d3vik2":{"opts":{"values":[{"uid":"2vvgb1hudfb","v":"H"},{"uid":"1n3scu8at0d","v":"I"},{"uid":"6o1eie3pr73","v":"J"},{"uid":"77hl1brl9ot","v":"K"}]},"type":"sort","condorcetmethod":"schulze"}}
+        var optionArray = ["H","I","J","K"]
+        var listOfLists = [["H","I","J","K"],["H","I","J","K"],["H","I","J","K"]]
 
-        
-
-        var result = Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify(["H"])
 
         cb(result);
-    }, "getSectionFromQ: ");  
+    }, "showCondorcetWinner: Check if correct winner calculated with 4 candidates, 3 votes - Schulze");  
 
+    assert(function (cb) {
+        var _answers = {"vy9HAs3lHjjdD6dob8azENP7J8F52/GfTdBGZP89LVo=|6ge8ff4tlob":{"msg":{"5nlo2d3vik2":["H","I","J","K"],"_uid":"6ge8ff4tlob","_time":1682023994086,"_hash":"vSFODg+ERjSNzluFBkTtNFWKwRX4VyNLaIoWHGdX/mdwEAJhYec37ezQ1NrSobTJ"},"hash":"vSFODg+ERjSNzluFBkTtNFWKwRX4VyNLaIoWHGdX/mdwEAJhYec37ezQ1NrSobTJ","time":1682023994086},"ojccyFYZAagrgbl2SeYK6flY3s6k49GLRC+95uE6vmU=|55q1cfmol3":{"msg":{"5nlo2d3vik2":["H","I","J","K"],"_uid":"55q1cfmol3","_time":1682024029120,"_hash":"mNMXSsj7+oQ41CUwmBDEkX5NItqRmhErFY6PynjF1n1qhdc13wCxlcs7geC3D9TR"},"hash":"mNMXSsj7+oQ41CUwmBDEkX5NItqRmhErFY6PynjF1n1qhdc13wCxlcs7geC3D9TR","time":1682024029120},"tzhcg6al6/bSBlusJsbMeULEr57UiUw2J3pgJcYFzi8=|7fr3t26hgpd":{"msg":{"5nlo2d3vik2":["H","I","J","K"],"_uid":"7fr3t26hgpd","_time":1682024076603,"_hash":"imVXZLoCT65lkuDh57kZ3cdr16/+d78Dx6R3Fu/ObmRkvdsBoc2t/j4w48Pcz28w"},"hash":"imVXZLoCT65lkuDh57kZ3cdr16/+d78Dx6R3Fu/ObmRkvdsBoc2t/j4w48Pcz28w","time":1682024076603}}
+        var opts = {"values":[{"uid":"2vvgb1hudfb","v":"H"},{"uid":"1n3scu8at0d","v":"I"},{"uid":"6o1eie3pr73","v":"J"},{"uid":"77hl1brl9ot","v":"K"}]}
+        var uid = "5nlo2d3vik2"
+        var form = {"5nlo2d3vik2":{"opts":{"values":[{"uid":"2vvgb1hudfb","v":"H"},{"uid":"1n3scu8at0d","v":"I"},{"uid":"6o1eie3pr73","v":"J"},{"uid":"77hl1brl9ot","v":"K"}]},"type":"sort","condorcetmethod":"ranked"}}
+        var optionArray = ["H","I","J","K"]
+        var listOfLists = [["H","I","J","K"],["H","I","J","K"],["H","I","J","K"]]
 
-    ///
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify(["H"])
+
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 4 candidates, 3 votes - Ranked Pairs");  
+
+    assert(function (cb) {
+        var _answers = {"BrRYeNfSyqahil0srSq01Y8iARtnyfXWYVIClnkk50Y=|2a862o47naf":{"msg":{"65r2p8gh5qf":["L","K","J","H","I"],"_uid":"2a862o47naf","_time":1681729438126,"_hash":"hlwB+VCYvtZk0qDS0fq1Gdy7owebExsmiko6EGNkt2kgEhb6nDSpHYCP2q3WvIy5"},"hash":"hlwB+VCYvtZk0qDS0fq1Gdy7owebExsmiko6EGNkt2kgEhb6nDSpHYCP2q3WvIy5","time":1681729438126},
+        "4MzNy/ngg+eD3lkzNjUkd+LLZuZQjqlVYGQSoPR5FFI=|48bl2bcqnt":{"msg":{"65r2p8gh5qf":["L","K","J","H","I"],"_uid":"48bl2bcqnt","_time":1681729479742,"_hash":"jgsfd4vtX3jsw6g71xYUaf9DdWTSb2v4UPgHG9fBZpjAp0JSYaH2pUC/koMbe4p3"},"hash":"jgsfd4vtX3jsw6g71xYUaf9DdWTSb2v4UPgHG9fBZpjAp0JSYaH2pUC/koMbe4p3","time":1681729479742},
+        "fFYzog7ADT2GzUfORIAuhCzntnHpKY2oRn0RlUnLEUY=|3cvbde3nhs7":{"msg":{"65r2p8gh5qf":["K","L","I","J","H"],"_uid":"3cvbde3nhs7","_time":1681729514124,"_hash":"KYqp7mc2MWYoHsFeI0x1z2MI7hGC8B/tYW0Bmxr/nKGGRnyWsNSEn2jkjMxtA/fR"},"hash":"KYqp7mc2MWYoHsFeI0x1z2MI7hGC8B/tYW0Bmxr/nKGGRnyWsNSEn2jkjMxtA/fR","time":1681729514124},
+        "/OGbAfIH5H/3DpaVLWPqpu5D326uLGZM42mkEmNq4js=|fcdvvu3mfo":{"msg":{"65r2p8gh5qf":["L","K","J","I","H"],"_uid":"fcdvvu3mfo","_time":1681729554074,"_hash":"H+pYz0PfMWPNDhu6x2SdAv+t4INyhuWrYEKwVnhlTf1cyNaaa2mg8WpgDFDwGr2H"},"hash":"H+pYz0PfMWPNDhu6x2SdAv+t4INyhuWrYEKwVnhlTf1cyNaaa2mg8WpgDFDwGr2H","time":1681729554074},
+        "S1v4WXaJ08I77ESVApP25wPO4pMpL3cmjDzXff9lXng=|156bst1uoie":{"msg":{"65r2p8gh5qf":["I","K","L","J","H"],"_uid":"156bst1uoie","_time":1681729592875,"_hash":"DcQ/+/bnCm5Gb/dc8kwcARO7H9bdnYVNF/la9HKp79bCDvwBenJ8gaMij7slunME"},"hash":"DcQ/+/bnCm5Gb/dc8kwcARO7H9bdnYVNF/la9HKp79bCDvwBenJ8gaMij7slunME","time":1681729592875},
+        "8K4aWZP1Mp/yL2p43R/VHl+PS1JIAEE5ioKOKlM2tzU=|1f5g4r4lcnb":{"msg":{"65r2p8gh5qf":["I","H","L","K","J"],"_uid":"1f5g4r4lcnb","_time":1681729633223,"_hash":"nthzCJW22uWQYQSzRmYcBkRusaB3kCI5F+uY8GilzhutXZ+4rwpu1h4ulixxPTts"},"hash":"nthzCJW22uWQYQSzRmYcBkRusaB3kCI5F+uY8GilzhutXZ+4rwpu1h4ulixxPTts","time":1681729633223},
+        "SQMP2n/pancHJ0dNBDO9sVkVgC5Lfg5lDDp1gXrwNjI=|4mrbrvtdjr2":{"msg":{"65r2p8gh5qf":["L","J","H","K","I"],"_uid":"4mrbrvtdjr2","_time":1681729673738,"_hash":"mgcfHEyk9TonLA9xoH73Ve0K2kKU5ERKCp+cKsD8j8Mo6W0vd/cUXOSwhQRKbldZ"},"hash":"mgcfHEyk9TonLA9xoH73Ve0K2kKU5ERKCp+cKsD8j8Mo6W0vd/cUXOSwhQRKbldZ","time":1681729673738},
+        "JebFB/gqx7jbQ1yASx2n/eRoCyj7EoqrkQaXi9Tt+Ag=|12sa31aoc89":{"msg":{"65r2p8gh5qf":["L","I","K","J","H"],"_uid":"12sa31aoc89","_time":1681729716164,"_hash":"nL4K2tEPhKTlNsy4uQay0aeGGHp1CN2WtWm8n3NMv7pjs8VxH8XJz6bTiVA+LS3W"},"hash":"nL4K2tEPhKTlNsy4uQay0aeGGHp1CN2WtWm8n3NMv7pjs8VxH8XJz6bTiVA+LS3W","time":1681729716164},
+        "l/GvVeqbpncsO7XBaT1wiawH7VCTbXp3gkgd0vsTTjI=|3kss4pjduva":{"msg":{"65r2p8gh5qf":["K","L","H","I","J"],"_uid":"3kss4pjduva","_time":1681729778475,"_hash":"xhP22oNoQGHyYxCSQVokr5G5f2aIgyFeMhPsE92vt75ZRbDNpGYxQSE0j/OYcvvU"},"hash":"xhP22oNoQGHyYxCSQVokr5G5f2aIgyFeMhPsE92vt75ZRbDNpGYxQSE0j/OYcvvU","time":1681729778475},
+        "V4o2zbWb/BxI1FN9A99y9yVHl1rvtvGHoU7qGfYwzHw=|18d1q89hnru":{"msg":{"65r2p8gh5qf":["J","I","K","L","H"],"_uid":"18d1q89hnru","_time":1681729810956,"_hash":"Jhv25IP/1CqPcoEJQGr2GgJVR0OH5BBHT8zbCCN5xM+4vJF6T06ZP2T/B3pwkzIb"},"hash":"Jhv25IP/1CqPcoEJQGr2GgJVR0OH5BBHT8zbCCN5xM+4vJF6T06ZP2T/B3pwkzIb","time":1681729810956}}
+        var opts = {"values":[{"uid":"2vvgb1hudfb","v":"H"},{"uid":"1n3scu8at0d","v":"I"},{"uid":"6o1eie3pr73","v":"J"},{"uid":"77hl1brl9ot","v":"K"}, {"uid":"77hl1brl9ot","v":"L"}]}
+        var uid = "5nlo2d3vik2"
+        var form = {"5nlo2d3vik2":{"opts":{"values":[{"uid":"2vvgb1hudfb","v":"H"},{"uid":"1n3scu8at0d","v":"I"},{"uid":"6o1eie3pr73","v":"J"},{"uid":"77hl1brl9ot","v":"K"}]},"type":"sort","condorcetmethod":"schulze"}}
+        var optionArray = ["H","I","J","K", "L"]
+        var listOfLists = [["L","K","J","H","I"],["L","K","J","H","I"],["K","L","I","J","H"],["L","K","J","I","H"],["I","K","L","J","H"],["I","H","L","K","J"],["L","J","H","K","I"],["L","I","K","J","H"],["K","L","H","I","J"],["J","I","K","L","H"]]
+
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify(["L"])
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 5 candidates, 10 votes - Schulze");  
+
+    assert(function (cb) {
+        var _answers = {"BrRYeNfSyqahil0srSq01Y8iARtnyfXWYVIClnkk50Y=|2a862o47naf":{"msg":{"65r2p8gh5qf":["L","K","J","H","I"],"_uid":"2a862o47naf","_time":1681729438126,"_hash":"hlwB+VCYvtZk0qDS0fq1Gdy7owebExsmiko6EGNkt2kgEhb6nDSpHYCP2q3WvIy5"},"hash":"hlwB+VCYvtZk0qDS0fq1Gdy7owebExsmiko6EGNkt2kgEhb6nDSpHYCP2q3WvIy5","time":1681729438126},
+        "4MzNy/ngg+eD3lkzNjUkd+LLZuZQjqlVYGQSoPR5FFI=|48bl2bcqnt":{"msg":{"65r2p8gh5qf":["L","K","J","H","I"],"_uid":"48bl2bcqnt","_time":1681729479742,"_hash":"jgsfd4vtX3jsw6g71xYUaf9DdWTSb2v4UPgHG9fBZpjAp0JSYaH2pUC/koMbe4p3"},"hash":"jgsfd4vtX3jsw6g71xYUaf9DdWTSb2v4UPgHG9fBZpjAp0JSYaH2pUC/koMbe4p3","time":1681729479742},
+        "fFYzog7ADT2GzUfORIAuhCzntnHpKY2oRn0RlUnLEUY=|3cvbde3nhs7":{"msg":{"65r2p8gh5qf":["K","L","I","J","H"],"_uid":"3cvbde3nhs7","_time":1681729514124,"_hash":"KYqp7mc2MWYoHsFeI0x1z2MI7hGC8B/tYW0Bmxr/nKGGRnyWsNSEn2jkjMxtA/fR"},"hash":"KYqp7mc2MWYoHsFeI0x1z2MI7hGC8B/tYW0Bmxr/nKGGRnyWsNSEn2jkjMxtA/fR","time":1681729514124},
+        "/OGbAfIH5H/3DpaVLWPqpu5D326uLGZM42mkEmNq4js=|fcdvvu3mfo":{"msg":{"65r2p8gh5qf":["L","K","J","I","H"],"_uid":"fcdvvu3mfo","_time":1681729554074,"_hash":"H+pYz0PfMWPNDhu6x2SdAv+t4INyhuWrYEKwVnhlTf1cyNaaa2mg8WpgDFDwGr2H"},"hash":"H+pYz0PfMWPNDhu6x2SdAv+t4INyhuWrYEKwVnhlTf1cyNaaa2mg8WpgDFDwGr2H","time":1681729554074},
+        "S1v4WXaJ08I77ESVApP25wPO4pMpL3cmjDzXff9lXng=|156bst1uoie":{"msg":{"65r2p8gh5qf":["I","K","L","J","H"],"_uid":"156bst1uoie","_time":1681729592875,"_hash":"DcQ/+/bnCm5Gb/dc8kwcARO7H9bdnYVNF/la9HKp79bCDvwBenJ8gaMij7slunME"},"hash":"DcQ/+/bnCm5Gb/dc8kwcARO7H9bdnYVNF/la9HKp79bCDvwBenJ8gaMij7slunME","time":1681729592875},
+        "8K4aWZP1Mp/yL2p43R/VHl+PS1JIAEE5ioKOKlM2tzU=|1f5g4r4lcnb":{"msg":{"65r2p8gh5qf":["I","H","L","K","J"],"_uid":"1f5g4r4lcnb","_time":1681729633223,"_hash":"nthzCJW22uWQYQSzRmYcBkRusaB3kCI5F+uY8GilzhutXZ+4rwpu1h4ulixxPTts"},"hash":"nthzCJW22uWQYQSzRmYcBkRusaB3kCI5F+uY8GilzhutXZ+4rwpu1h4ulixxPTts","time":1681729633223},
+        "SQMP2n/pancHJ0dNBDO9sVkVgC5Lfg5lDDp1gXrwNjI=|4mrbrvtdjr2":{"msg":{"65r2p8gh5qf":["L","J","H","K","I"],"_uid":"4mrbrvtdjr2","_time":1681729673738,"_hash":"mgcfHEyk9TonLA9xoH73Ve0K2kKU5ERKCp+cKsD8j8Mo6W0vd/cUXOSwhQRKbldZ"},"hash":"mgcfHEyk9TonLA9xoH73Ve0K2kKU5ERKCp+cKsD8j8Mo6W0vd/cUXOSwhQRKbldZ","time":1681729673738},
+        "JebFB/gqx7jbQ1yASx2n/eRoCyj7EoqrkQaXi9Tt+Ag=|12sa31aoc89":{"msg":{"65r2p8gh5qf":["L","I","K","J","H"],"_uid":"12sa31aoc89","_time":1681729716164,"_hash":"nL4K2tEPhKTlNsy4uQay0aeGGHp1CN2WtWm8n3NMv7pjs8VxH8XJz6bTiVA+LS3W"},"hash":"nL4K2tEPhKTlNsy4uQay0aeGGHp1CN2WtWm8n3NMv7pjs8VxH8XJz6bTiVA+LS3W","time":1681729716164},
+        "l/GvVeqbpncsO7XBaT1wiawH7VCTbXp3gkgd0vsTTjI=|3kss4pjduva":{"msg":{"65r2p8gh5qf":["K","L","H","I","J"],"_uid":"3kss4pjduva","_time":1681729778475,"_hash":"xhP22oNoQGHyYxCSQVokr5G5f2aIgyFeMhPsE92vt75ZRbDNpGYxQSE0j/OYcvvU"},"hash":"xhP22oNoQGHyYxCSQVokr5G5f2aIgyFeMhPsE92vt75ZRbDNpGYxQSE0j/OYcvvU","time":1681729778475},
+        "V4o2zbWb/BxI1FN9A99y9yVHl1rvtvGHoU7qGfYwzHw=|18d1q89hnru":{"msg":{"65r2p8gh5qf":["J","I","K","L","H"],"_uid":"18d1q89hnru","_time":1681729810956,"_hash":"Jhv25IP/1CqPcoEJQGr2GgJVR0OH5BBHT8zbCCN5xM+4vJF6T06ZP2T/B3pwkzIb"},"hash":"Jhv25IP/1CqPcoEJQGr2GgJVR0OH5BBHT8zbCCN5xM+4vJF6T06ZP2T/B3pwkzIb","time":1681729810956}}
+        var opts = {"values":[{"uid":"2vvgb1hudfb","v":"H"},{"uid":"1n3scu8at0d","v":"I"},{"uid":"6o1eie3pr73","v":"J"},{"uid":"77hl1brl9ot","v":"K"}, {"uid":"77hl1brl9ot","v":"L"}]}
+        var uid = "5nlo2d3vik2"
+        var form = {"5nlo2d3vik2":{"opts":{"values":[{"uid":"2vvgb1hudfb","v":"H"},{"uid":"1n3scu8at0d","v":"I"},{"uid":"6o1eie3pr73","v":"J"},{"uid":"77hl1brl9ot","v":"K"}]},"type":"sort","condorcetmethod":"ranked"}}
+        var optionArray = ["H","I","J","K", "L"]
+        var listOfLists = [["L","K","J","H","I"],["L","K","J","H","I"],["K","L","I","J","H"],["L","K","J","I","H"],["I","K","L","J","H"],["I","H","L","K","J"],["L","J","H","K","I"],["L","I","K","J","H"],["K","L","H","I","J"],["J","I","K","L","H"]]
+
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify(["L"])
+
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 5 candidates, 10 votes - Ranked Pairs");  
+
+    assert(function (cb) {
+        var _answers = {"AtqEIJD75kH0JNnubl9DyF8A3ygeUuCArKobfj1hMAo=|3nv303ppc9n":{"msg":{"1jb9rrcvoc2":["H","I","J","K"],"_uid":"3nv303ppc9n","_time":1681691174852,"_hash":"uj1gv3wDiYci/HnTQy1/kdqWR1WJbSGK96pjaEd1K6VCeFX+Q9rg/hex5tVOvWUh"},"hash":"uj1gv3wDiYci/HnTQy1/kdqWR1WJbSGK96pjaEd1K6VCeFX+Q9rg/hex5tVOvWUh","time":1681691174852}, "cUc1IgcyiworYhYg4HRux6lUBh/Do2pkWzj4L+og/RQ=|1snqaj863vt":{"msg":{"1jb9rrcvoc2":["I","H","J","K"],"_uid":"1snqaj863vt","_time":1681691214226,"_hash":"KKj7l8MFEjkboTeBrFc5xa4w8384PGedxer1VXt6d55wE4l3Okpy6fRhRinWnjNq"},"hash":"KKj7l8MFEjkboTeBrFc5xa4w8384PGedxer1VXt6d55wE4l3Okpy6fRhRinWnjNq","time":1681691214226}, "2FRwA83fQmnfQQWZdDP0XZPSsdm3GXjSe+83tEMheSw=|6o5mdpjn3kg":{"msg":{"1jb9rrcvoc2":["J","H","I","K"],"_uid":"6o5mdpjn3kg","_time":1681691249979,"_hash":"K5qthAGHeU+Ap4nBE/i5VeMUefnxS0pyFDrBLFvEvMGJ4JCslGS5Ny3Y0wqncHJJ"},"hash":"K5qthAGHeU+Ap4nBE/i5VeMUefnxS0pyFDrBLFvEvMGJ4JCslGS5Ny3Y0wqncHJJ","time":1681691249979},
+        "6BCq4pys/NolQOtcBflOcYtmP1huKfvM+Z61fQ0Gn1M=|rdc3epmuh7":{"msg":{"1jb9rrcvoc2":["K","H","I","J"],"_uid":"rdc3epmuh7","_time":1681691294180,"_hash":"ClCx83SXaAjHsNJ+OEALxsMwKvMWvysNcnMYMqTU7j/F/7IWvrO3Yp6CIlAyXSz/"},"hash":"ClCx83SXaAjHsNJ+OEALxsMwKvMWvysNcnMYMqTU7j/F/7IWvrO3Yp6CIlAyXSz/","time":1681691294180},
+        "U4SSHuTrrPTAKIIbZ31yN9uwEYfrFO0hd24sEoCatW0=|5c0gsctlfa3":{"msg":{"1jb9rrcvoc2":["J","K","I","H"],"_uid":"5c0gsctlfa3","_time":1681691329715,"_hash":"Sin191I6D3nEqR1WbKFLqANlHSBO/G79g8sx4KYRGfdwrQrzrYMN3CmgJfKkJmH1"},"hash":"Sin191I6D3nEqR1WbKFLqANlHSBO/G79g8sx4KYRGfdwrQrzrYMN3CmgJfKkJmH1","time":1681691329715},
+        "HQdIprb544HD5r90txGofCfN/ixylbVYgrusFGXkDU4=|14fbfb8hb29":{"msg":{"1jb9rrcvoc2":["K","I","H","J"],"_uid":"14fbfb8hb29","_time":1681691363758,"_hash":"TNrqKd9bsewsDWYlYHSH1ojEUj+qUABXVycgk3VnK29FY/1Mic+NF/aOM1UCyHHV"},"hash":"TNrqKd9bsewsDWYlYHSH1ojEUj+qUABXVycgk3VnK29FY/1Mic+NF/aOM1UCyHHV","time":1681691363758},
+        "Pxy28SkQA+ii90aj6OsocG47Z3tq/7timwZPlDVnSzU=|17i15n4stru":{"msg":{"1jb9rrcvoc2":["J","H","K","I"],"_uid":"17i15n4stru","_time":1681691458380,"_hash":"x3wMejkzQ3dWjV/DZacAusFhBz47Zr6wAzIRJPP4CJWStxq0EB9iQPoyKVoTiNH4"},"hash":"x3wMejkzQ3dWjV/DZacAusFhBz47Zr6wAzIRJPP4CJWStxq0EB9iQPoyKVoTiNH4","time":1681691458380},
+        "MhX8MY3Vl4ZWhN6zu8T29QaU5Uxc29h0XBuqIt6PKnE=|76mbjm31shk":{"msg":{"1jb9rrcvoc2":["I","K","J","H"],"_uid":"76mbjm31shk","_time":1681691646905,"_hash":"jbJJ6jd4yJL5WXgbO4Wn9sUY2HKXAflLXU1Aahmr2aNZatyyWeX6vX4D19VB3z+j"},"hash":"jbJJ6jd4yJL5WXgbO4Wn9sUY2HKXAflLXU1Aahmr2aNZatyyWeX6vX4D19VB3z+j","time":1681691646905},
+        "fDlnRZoxOC1P+pq8vgTn529jQfgl6arr5yhlLMXF7Us=|9nunhvjc3d":{"msg":{"1jb9rrcvoc2":["I","K","J","H"],"_uid":"9nunhvjc3d","_time":1681691706061,"_hash":"4XsvGVemRt1+jRjgN2hphMaw03YpM4Hip49aJDPWBdEGwhKica1gmJMDTp07L79i"},"hash":"4XsvGVemRt1+jRjgN2hphMaw03YpM4Hip49aJDPWBdEGwhKica1gmJMDTp07L79i","time":1681691706061}, 
+        "f+/uzRwTUMck51HyqTN8s8QtETO7cqjhD80j/HNO7Bc=|1le2eskh2bc":{"msg":{"1jb9rrcvoc2":["I","J","K","H"],"_uid":"1le2eskh2bc","_time":1681691742592,"_hash":"bMzuEN6LDY2Hj2CRU0ITdlz8/cJRFNWgdTwE28nv0GYYG7TzP89bWWxnRg3FLgb5"},"hash":"bMzuEN6LDY2Hj2CRU0ITdlz8/cJRFNWgdTwE28nv0GYYG7TzP89bWWxnRg3FLgb5","time":1681691742592}}
+        var opts = {"values":[{"uid":"343p2rnve50","v":"H"},{"uid":"7rgol8gpe2m","v":"I"},{"uid":"3u0id5u18db","v":"J"},{"uid":"5ghoh24cpjl","v":"K"}]}
+        var uid = "1jb9rrcvoc2"
+        var form = {"1jb9rrcvoc2":{"opts":{"values":[{"uid":"343p2rnve50","v":"H"},{"uid":"7rgol8gpe2m","v":"I"},{"uid":"3u0id5u18db","v":"J"},{"uid":"5ghoh24cpjl","v":"K"}]},"type":"sort","condorcetmethod":"schulze"}}
+        var optionArray = ["H","I","J","K"]
+        var listOfLists = [["H","I","J","K"],["I","H","J","K"],["J","H","I","K"],["K","H","I","J"],["J","K","I","H"],["K","I","H","J"],["J","H","K","I"],["I","K","J","H"],["I","K","J","H"],["I","J","K","H"]]
+
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify(["I"])
+
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 4 candidates, 10 votes - Schulze");  
+
+    assert(function (cb) {
+        var _answers = {"AtqEIJD75kH0JNnubl9DyF8A3ygeUuCArKobfj1hMAo=|3nv303ppc9n":{"msg":{"1jb9rrcvoc2":["H","I","J","K"],"_uid":"3nv303ppc9n","_time":1681691174852,"_hash":"uj1gv3wDiYci/HnTQy1/kdqWR1WJbSGK96pjaEd1K6VCeFX+Q9rg/hex5tVOvWUh"},"hash":"uj1gv3wDiYci/HnTQy1/kdqWR1WJbSGK96pjaEd1K6VCeFX+Q9rg/hex5tVOvWUh","time":1681691174852}, "cUc1IgcyiworYhYg4HRux6lUBh/Do2pkWzj4L+og/RQ=|1snqaj863vt":{"msg":{"1jb9rrcvoc2":["I","H","J","K"],"_uid":"1snqaj863vt","_time":1681691214226,"_hash":"KKj7l8MFEjkboTeBrFc5xa4w8384PGedxer1VXt6d55wE4l3Okpy6fRhRinWnjNq"},"hash":"KKj7l8MFEjkboTeBrFc5xa4w8384PGedxer1VXt6d55wE4l3Okpy6fRhRinWnjNq","time":1681691214226}, "2FRwA83fQmnfQQWZdDP0XZPSsdm3GXjSe+83tEMheSw=|6o5mdpjn3kg":{"msg":{"1jb9rrcvoc2":["J","H","I","K"],"_uid":"6o5mdpjn3kg","_time":1681691249979,"_hash":"K5qthAGHeU+Ap4nBE/i5VeMUefnxS0pyFDrBLFvEvMGJ4JCslGS5Ny3Y0wqncHJJ"},"hash":"K5qthAGHeU+Ap4nBE/i5VeMUefnxS0pyFDrBLFvEvMGJ4JCslGS5Ny3Y0wqncHJJ","time":1681691249979},
+        "6BCq4pys/NolQOtcBflOcYtmP1huKfvM+Z61fQ0Gn1M=|rdc3epmuh7":{"msg":{"1jb9rrcvoc2":["K","H","I","J"],"_uid":"rdc3epmuh7","_time":1681691294180,"_hash":"ClCx83SXaAjHsNJ+OEALxsMwKvMWvysNcnMYMqTU7j/F/7IWvrO3Yp6CIlAyXSz/"},"hash":"ClCx83SXaAjHsNJ+OEALxsMwKvMWvysNcnMYMqTU7j/F/7IWvrO3Yp6CIlAyXSz/","time":1681691294180},
+        "U4SSHuTrrPTAKIIbZ31yN9uwEYfrFO0hd24sEoCatW0=|5c0gsctlfa3":{"msg":{"1jb9rrcvoc2":["J","K","I","H"],"_uid":"5c0gsctlfa3","_time":1681691329715,"_hash":"Sin191I6D3nEqR1WbKFLqANlHSBO/G79g8sx4KYRGfdwrQrzrYMN3CmgJfKkJmH1"},"hash":"Sin191I6D3nEqR1WbKFLqANlHSBO/G79g8sx4KYRGfdwrQrzrYMN3CmgJfKkJmH1","time":1681691329715},
+        "HQdIprb544HD5r90txGofCfN/ixylbVYgrusFGXkDU4=|14fbfb8hb29":{"msg":{"1jb9rrcvoc2":["K","I","H","J"],"_uid":"14fbfb8hb29","_time":1681691363758,"_hash":"TNrqKd9bsewsDWYlYHSH1ojEUj+qUABXVycgk3VnK29FY/1Mic+NF/aOM1UCyHHV"},"hash":"TNrqKd9bsewsDWYlYHSH1ojEUj+qUABXVycgk3VnK29FY/1Mic+NF/aOM1UCyHHV","time":1681691363758},
+        "Pxy28SkQA+ii90aj6OsocG47Z3tq/7timwZPlDVnSzU=|17i15n4stru":{"msg":{"1jb9rrcvoc2":["J","H","K","I"],"_uid":"17i15n4stru","_time":1681691458380,"_hash":"x3wMejkzQ3dWjV/DZacAusFhBz47Zr6wAzIRJPP4CJWStxq0EB9iQPoyKVoTiNH4"},"hash":"x3wMejkzQ3dWjV/DZacAusFhBz47Zr6wAzIRJPP4CJWStxq0EB9iQPoyKVoTiNH4","time":1681691458380},
+        "MhX8MY3Vl4ZWhN6zu8T29QaU5Uxc29h0XBuqIt6PKnE=|76mbjm31shk":{"msg":{"1jb9rrcvoc2":["I","K","J","H"],"_uid":"76mbjm31shk","_time":1681691646905,"_hash":"jbJJ6jd4yJL5WXgbO4Wn9sUY2HKXAflLXU1Aahmr2aNZatyyWeX6vX4D19VB3z+j"},"hash":"jbJJ6jd4yJL5WXgbO4Wn9sUY2HKXAflLXU1Aahmr2aNZatyyWeX6vX4D19VB3z+j","time":1681691646905},
+        "fDlnRZoxOC1P+pq8vgTn529jQfgl6arr5yhlLMXF7Us=|9nunhvjc3d":{"msg":{"1jb9rrcvoc2":["I","K","J","H"],"_uid":"9nunhvjc3d","_time":1681691706061,"_hash":"4XsvGVemRt1+jRjgN2hphMaw03YpM4Hip49aJDPWBdEGwhKica1gmJMDTp07L79i"},"hash":"4XsvGVemRt1+jRjgN2hphMaw03YpM4Hip49aJDPWBdEGwhKica1gmJMDTp07L79i","time":1681691706061}, 
+        "f+/uzRwTUMck51HyqTN8s8QtETO7cqjhD80j/HNO7Bc=|1le2eskh2bc":{"msg":{"1jb9rrcvoc2":["I","J","K","H"],"_uid":"1le2eskh2bc","_time":1681691742592,"_hash":"bMzuEN6LDY2Hj2CRU0ITdlz8/cJRFNWgdTwE28nv0GYYG7TzP89bWWxnRg3FLgb5"},"hash":"bMzuEN6LDY2Hj2CRU0ITdlz8/cJRFNWgdTwE28nv0GYYG7TzP89bWWxnRg3FLgb5","time":1681691742592}}
+        var opts = {"values":[{"uid":"343p2rnve50","v":"H"},{"uid":"7rgol8gpe2m","v":"I"},{"uid":"3u0id5u18db","v":"J"},{"uid":"5ghoh24cpjl","v":"K"}]}
+        var uid = "1jb9rrcvoc2"
+        var form = {"1jb9rrcvoc2":{"opts":{"values":[{"uid":"343p2rnve50","v":"H"},{"uid":"7rgol8gpe2m","v":"I"},{"uid":"3u0id5u18db","v":"J"},{"uid":"5ghoh24cpjl","v":"K"}]},"type":"sort","condorcetmethod":"ranked"}}
+        var optionArray = ["H","I","J","K"]
+        var listOfLists = [["H","I","J","K"],["I","H","J","K"],["J","H","I","K"],["K","H","I","J"],["J","K","I","H"],["K","I","H","J"],["J","H","K","I"],["I","K","J","H"],["I","K","J","H"],["I","J","K","H"]]
+
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify(["I"])
+
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 4 candidates, 10 votes - Ranked Pairs");  
+
+    assert(function (cb) {
+        var _answers = {"BwFNlRhW3AJ6QoZpWBu7ftHNtNWk0haprwH3NFbRTm0=|npg0bseejf":{"msg":{"67h4dnpga2u":["H","I","J","K"],"_uid":"npg0bseejf","_time":1681683945756,"_hash":"KLyDtbc8djGStL+4BlbI+O3ZZ+VQPiLCShBZrfF7UpbwgowL4tfUUNwCt00JXmPA"},"hash":"KLyDtbc8djGStL+4BlbI+O3ZZ+VQPiLCShBZrfF7UpbwgowL4tfUUNwCt00JXmPA","time":1681683945756}, 
+        "xH+s8g8LQX96ROrfNWiHbnZQJwDr/9tyeHIEaBOHbFk=|3mc41g9vm2":{"msg":{"67h4dnpga2u":["H","I","K","J"],"_uid":"3mc41g9vm2","_time":1681683980059,"_hash":"MEDDfYVEVWityy3M3GSTx8wOEkzIATf8rA0ovKOuCS7+U0ZlIWdBvwBITRWFGRkX"},"hash":"MEDDfYVEVWityy3M3GSTx8wOEkzIATf8rA0ovKOuCS7+U0ZlIWdBvwBITRWFGRkX","time":1681683980059},
+        "supWCR2B/1dycFXkj8qD8OGDGHwKJ2CEAof8Sm/RkEI=|5k61emebluc":{"msg":{"67h4dnpga2u":["H","I","K","J"],"_uid":"5k61emebluc","_time":1681684008298,"_hash":"Zb/oTSYiAAOGzGjvcax52SVioX+2BRbElvwYkugCZRAPk2DNJE6lNZRa5tle2m/i"},"hash":"Zb/oTSYiAAOGzGjvcax52SVioX+2BRbElvwYkugCZRAPk2DNJE6lNZRa5tle2m/i","time":1681684008298},
+        "ih11i7GE/bp/GHaB/1KRVns+06NWyrlXoPBdmVF48hI=|1i7ttfaldgf":{"msg":{"67h4dnpga2u":["H","I","J","K"],"_uid":"1i7ttfaldgf","_time":1681684047183,"_hash":"HkBBM/qn/uEFCl9dRpVZJ0gkCzckojenHj0bwwoguRM1QVBXbpNQORkSYHcDgzq3"},"hash":"HkBBM/qn/uEFCl9dRpVZJ0gkCzckojenHj0bwwoguRM1QVBXbpNQORkSYHcDgzq3","time":1681684047183},
+        "iDElng/HcmiHOryTGq5kz5SE9hTcMVM1MJYjiHbnLzw=|479j9agkcrr":{"msg":{"67h4dnpga2u":["I","H","J","K"],"_uid":"479j9agkcrr","_time":1681684083988,"_hash":"thR9o+mwCE/1USx7ltar8XjVZleLUR4V4pL9P8iq3Zdc3vZSuQp8IDtsCObK9Hl1"},"hash":"thR9o+mwCE/1USx7ltar8XjVZleLUR4V4pL9P8iq3Zdc3vZSuQp8IDtsCObK9Hl1","time":1681684083988},
+        "Jc9p8GqjTqn5yBRGxTrD9bKjCPLFYT01UlAOMF9SKkY=|12e79jk9up6":{"msg":{"67h4dnpga2u":["J","H","I","K"],"_uid":"12e79jk9up6","_time":1681684108805,"_hash":"oeCXA7/emTP7J7EtOthxl1KbmPAck1LFYMyPju5ymzshfeXhaUKB4jExQXp7L9cH"},"hash":"oeCXA7/emTP7J7EtOthxl1KbmPAck1LFYMyPju5ymzshfeXhaUKB4jExQXp7L9cH","time":1681684108805},
+        "lBcd667EdQdPmm+40wQFh6urLRYoz4oJHn1QEg7AHGk=|49ibtfuhns8":{"msg":{"67h4dnpga2u":["K","H","I","J"],"_uid":"49ibtfuhns8","_time":1681684135097,"_hash":"w7g+OmtNwbo+4kUp++hcQx5ecI0gTvQvRY1vAfQfEqiNvW7ymNPQObm8IsQQA1yN"},"hash":"w7g+OmtNwbo+4kUp++hcQx5ecI0gTvQvRY1vAfQfEqiNvW7ymNPQObm8IsQQA1yN","time":1681684135097},
+        "sBHJDrJsCl3uEM0MaID9AW+z+c9RNaaeMq28wW41on8=|5nii53nilin":{"msg":{"67h4dnpga2u":["J","K","I","H"],"_uid":"5nii53nilin","_time":1681684187952,"_hash":"V0rYAG/QyBXFSl7w3aaI45uu4pplq93Ym4vYbgXMQA/hXstgyMvAjKrWF6ZsAZOO"},"hash":"V0rYAG/QyBXFSl7w3aaI45uu4pplq93Ym4vYbgXMQA/hXstgyMvAjKrWF6ZsAZOO","time":1681684187952},
+        "Fb+PF0OoDZVkcm6LRwDrn/hQlbI2NBEEd5htvCvaD1E=|4hcirvtqmb4":{"msg":{"67h4dnpga2u":["K","I","H","J"],"_uid":"4hcirvtqmb4","_time":1681684215849,"_hash":"OL7o/qOdMCnCXVU+N+RZufraqH4/rmcvhEsARcmaXaCXXhEf3RrtiJtPoDlE9YJH"},"hash":"OL7o/qOdMCnCXVU+N+RZufraqH4/rmcvhEsARcmaXaCXXhEf3RrtiJtPoDlE9YJH","time":1681684215849},
+        "RkfhULdUpYuHvMSkYpTH4wEfNoKEdDQAh4KNRqY//gY=|5b6pccgc5nc":{"msg":{"67h4dnpga2u":["J","H","K","I"],"_uid":"5b6pccgc5nc","_time":1681684240353,"_hash":"D06d3o18nJQIVh4MxmKUoVLxAPHnv8FpRIpXVJqvB5i5GeFwjqS+0ci802q9LReg"},"hash":"D06d3o18nJQIVh4MxmKUoVLxAPHnv8FpRIpXVJqvB5i5GeFwjqS+0ci802q9LReg","time":1681684240353},
+        "jccOnPAwGNvijYp30HuiNV36TXOEgpFJjbie4X6gihY=|ie5e4tdnlr":{"msg":{"67h4dnpga2u":["I","K","J","H"],"_uid":"ie5e4tdnlr","_time":1681684305411,"_hash":"mnCcDKV5U8jPdFE0V/ZcKIrm8XiBntTdzE90mSjoW1Uu4cvfgNHZ0qFpobig8jXh"},"hash":"mnCcDKV5U8jPdFE0V/ZcKIrm8XiBntTdzE90mSjoW1Uu4cvfgNHZ0qFpobig8jXh","time":1681684305411},
+        "qQk/Qf62A7RPKElBOVX6WrhMoJcR15QC93t7AjT05lA=|ic51icvcbq":{"msg":{"67h4dnpga2u":["I","K","J","H"],"_uid":"ic51icvcbq","_time":1681684326463,"_hash":"6v0pQapT4J+D6NwW5INI8lmXh8HMptNBPNB5mDtVq+6QWIu0R2gvWgdRdJTJZiSp"},"hash":"6v0pQapT4J+D6NwW5INI8lmXh8HMptNBPNB5mDtVq+6QWIu0R2gvWgdRdJTJZiSp","time":1681684326463},
+        "QcJq5/CEaQ+8b2NPB6nnZMYHPDVAGySTtJEDF7CCnyE=|2feftir9d2h":{"msg":{"67h4dnpga2u":["I","J","K","H"],"_uid":"2feftir9d2h","_time":1681684348001,"_hash":"HbETuw3JeFnKSVGzsfeKOyx4lim1MIwaDwkG66HPb+AHpqiEglf3yfhQPBTQfQAt"},"hash":"HbETuw3JeFnKSVGzsfeKOyx4lim1MIwaDwkG66HPb+AHpqiEglf3yfhQPBTQfQAt","time":1681684348001}}
+        var opts = {"values":[{"uid":"1h7i5i6e3kl","v":"H"},{"uid":"5k30663hga6","v":"I"},{"uid":"29t5n7nn8dv","v":"J"},{"uid":"3du0483fuih","v":"K"}]}
+        var uid = "67h4dnpga2u"
+        var form = {"67h4dnpga2u":{"condorcetmethod":"schulze","opts":{"values":[{"uid":"1h7i5i6e3kl","v":"H"},{"uid":"5k30663hga6","v":"I"},{"uid":"29t5n7nn8dv","v":"J"},{"uid":"3du0483fuih","v":"K"}]},"type":"sort"}}
+        var optionArray = ["H","I","J","K"]
+        var listOfLists = [["H","I","J","K"],["H","I","K","J"],["H","I","K","J"],["H","I","J","K"],["I","H","J","K"],["J","H","I","K"],["K","H","I","J"],["J","K","I","H"],["K","I","H","J"],["J","H","K","I"],["I","K","J","H"],["I","K","J","H"],["I","J","K","H"]]
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify(["H"])
+
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 4 candidates, 13 votes - Schulze");  
+
+    assert(function (cb) {
+        var _answers = {"BwFNlRhW3AJ6QoZpWBu7ftHNtNWk0haprwH3NFbRTm0=|npg0bseejf":{"msg":{"67h4dnpga2u":["H","I","J","K"],"_uid":"npg0bseejf","_time":1681683945756,"_hash":"KLyDtbc8djGStL+4BlbI+O3ZZ+VQPiLCShBZrfF7UpbwgowL4tfUUNwCt00JXmPA"},"hash":"KLyDtbc8djGStL+4BlbI+O3ZZ+VQPiLCShBZrfF7UpbwgowL4tfUUNwCt00JXmPA","time":1681683945756}, 
+        "xH+s8g8LQX96ROrfNWiHbnZQJwDr/9tyeHIEaBOHbFk=|3mc41g9vm2":{"msg":{"67h4dnpga2u":["H","I","K","J"],"_uid":"3mc41g9vm2","_time":1681683980059,"_hash":"MEDDfYVEVWityy3M3GSTx8wOEkzIATf8rA0ovKOuCS7+U0ZlIWdBvwBITRWFGRkX"},"hash":"MEDDfYVEVWityy3M3GSTx8wOEkzIATf8rA0ovKOuCS7+U0ZlIWdBvwBITRWFGRkX","time":1681683980059},
+        "supWCR2B/1dycFXkj8qD8OGDGHwKJ2CEAof8Sm/RkEI=|5k61emebluc":{"msg":{"67h4dnpga2u":["H","I","K","J"],"_uid":"5k61emebluc","_time":1681684008298,"_hash":"Zb/oTSYiAAOGzGjvcax52SVioX+2BRbElvwYkugCZRAPk2DNJE6lNZRa5tle2m/i"},"hash":"Zb/oTSYiAAOGzGjvcax52SVioX+2BRbElvwYkugCZRAPk2DNJE6lNZRa5tle2m/i","time":1681684008298},
+        "ih11i7GE/bp/GHaB/1KRVns+06NWyrlXoPBdmVF48hI=|1i7ttfaldgf":{"msg":{"67h4dnpga2u":["H","I","J","K"],"_uid":"1i7ttfaldgf","_time":1681684047183,"_hash":"HkBBM/qn/uEFCl9dRpVZJ0gkCzckojenHj0bwwoguRM1QVBXbpNQORkSYHcDgzq3"},"hash":"HkBBM/qn/uEFCl9dRpVZJ0gkCzckojenHj0bwwoguRM1QVBXbpNQORkSYHcDgzq3","time":1681684047183},
+        "iDElng/HcmiHOryTGq5kz5SE9hTcMVM1MJYjiHbnLzw=|479j9agkcrr":{"msg":{"67h4dnpga2u":["I","H","J","K"],"_uid":"479j9agkcrr","_time":1681684083988,"_hash":"thR9o+mwCE/1USx7ltar8XjVZleLUR4V4pL9P8iq3Zdc3vZSuQp8IDtsCObK9Hl1"},"hash":"thR9o+mwCE/1USx7ltar8XjVZleLUR4V4pL9P8iq3Zdc3vZSuQp8IDtsCObK9Hl1","time":1681684083988},
+        "Jc9p8GqjTqn5yBRGxTrD9bKjCPLFYT01UlAOMF9SKkY=|12e79jk9up6":{"msg":{"67h4dnpga2u":["J","H","I","K"],"_uid":"12e79jk9up6","_time":1681684108805,"_hash":"oeCXA7/emTP7J7EtOthxl1KbmPAck1LFYMyPju5ymzshfeXhaUKB4jExQXp7L9cH"},"hash":"oeCXA7/emTP7J7EtOthxl1KbmPAck1LFYMyPju5ymzshfeXhaUKB4jExQXp7L9cH","time":1681684108805},
+        "lBcd667EdQdPmm+40wQFh6urLRYoz4oJHn1QEg7AHGk=|49ibtfuhns8":{"msg":{"67h4dnpga2u":["K","H","I","J"],"_uid":"49ibtfuhns8","_time":1681684135097,"_hash":"w7g+OmtNwbo+4kUp++hcQx5ecI0gTvQvRY1vAfQfEqiNvW7ymNPQObm8IsQQA1yN"},"hash":"w7g+OmtNwbo+4kUp++hcQx5ecI0gTvQvRY1vAfQfEqiNvW7ymNPQObm8IsQQA1yN","time":1681684135097},
+        "sBHJDrJsCl3uEM0MaID9AW+z+c9RNaaeMq28wW41on8=|5nii53nilin":{"msg":{"67h4dnpga2u":["J","K","I","H"],"_uid":"5nii53nilin","_time":1681684187952,"_hash":"V0rYAG/QyBXFSl7w3aaI45uu4pplq93Ym4vYbgXMQA/hXstgyMvAjKrWF6ZsAZOO"},"hash":"V0rYAG/QyBXFSl7w3aaI45uu4pplq93Ym4vYbgXMQA/hXstgyMvAjKrWF6ZsAZOO","time":1681684187952},
+        "Fb+PF0OoDZVkcm6LRwDrn/hQlbI2NBEEd5htvCvaD1E=|4hcirvtqmb4":{"msg":{"67h4dnpga2u":["K","I","H","J"],"_uid":"4hcirvtqmb4","_time":1681684215849,"_hash":"OL7o/qOdMCnCXVU+N+RZufraqH4/rmcvhEsARcmaXaCXXhEf3RrtiJtPoDlE9YJH"},"hash":"OL7o/qOdMCnCXVU+N+RZufraqH4/rmcvhEsARcmaXaCXXhEf3RrtiJtPoDlE9YJH","time":1681684215849},
+        "RkfhULdUpYuHvMSkYpTH4wEfNoKEdDQAh4KNRqY//gY=|5b6pccgc5nc":{"msg":{"67h4dnpga2u":["J","H","K","I"],"_uid":"5b6pccgc5nc","_time":1681684240353,"_hash":"D06d3o18nJQIVh4MxmKUoVLxAPHnv8FpRIpXVJqvB5i5GeFwjqS+0ci802q9LReg"},"hash":"D06d3o18nJQIVh4MxmKUoVLxAPHnv8FpRIpXVJqvB5i5GeFwjqS+0ci802q9LReg","time":1681684240353},
+        "jccOnPAwGNvijYp30HuiNV36TXOEgpFJjbie4X6gihY=|ie5e4tdnlr":{"msg":{"67h4dnpga2u":["I","K","J","H"],"_uid":"ie5e4tdnlr","_time":1681684305411,"_hash":"mnCcDKV5U8jPdFE0V/ZcKIrm8XiBntTdzE90mSjoW1Uu4cvfgNHZ0qFpobig8jXh"},"hash":"mnCcDKV5U8jPdFE0V/ZcKIrm8XiBntTdzE90mSjoW1Uu4cvfgNHZ0qFpobig8jXh","time":1681684305411},
+        "qQk/Qf62A7RPKElBOVX6WrhMoJcR15QC93t7AjT05lA=|ic51icvcbq":{"msg":{"67h4dnpga2u":["I","K","J","H"],"_uid":"ic51icvcbq","_time":1681684326463,"_hash":"6v0pQapT4J+D6NwW5INI8lmXh8HMptNBPNB5mDtVq+6QWIu0R2gvWgdRdJTJZiSp"},"hash":"6v0pQapT4J+D6NwW5INI8lmXh8HMptNBPNB5mDtVq+6QWIu0R2gvWgdRdJTJZiSp","time":1681684326463},
+        "QcJq5/CEaQ+8b2NPB6nnZMYHPDVAGySTtJEDF7CCnyE=|2feftir9d2h":{"msg":{"67h4dnpga2u":["I","J","K","H"],"_uid":"2feftir9d2h","_time":1681684348001,"_hash":"HbETuw3JeFnKSVGzsfeKOyx4lim1MIwaDwkG66HPb+AHpqiEglf3yfhQPBTQfQAt"},"hash":"HbETuw3JeFnKSVGzsfeKOyx4lim1MIwaDwkG66HPb+AHpqiEglf3yfhQPBTQfQAt","time":1681684348001}}
+        var opts = {"values":[{"uid":"1h7i5i6e3kl","v":"H"},{"uid":"5k30663hga6","v":"I"},{"uid":"29t5n7nn8dv","v":"J"},{"uid":"3du0483fuih","v":"K"}]}
+        var uid = "67h4dnpga2u"
+        var form = {"67h4dnpga2u":{"condorcetmethod":"ranked","opts":{"values":[{"uid":"1h7i5i6e3kl","v":"H"},{"uid":"5k30663hga6","v":"I"},{"uid":"29t5n7nn8dv","v":"J"},{"uid":"3du0483fuih","v":"K"}]},"type":"sort"}}
+        var optionArray = ["H","I","J","K"]
+        var listOfLists = [["H","I","J","K"],["H","I","K","J"],["H","I","K","J"],["H","I","J","K"],["I","H","J","K"],["J","H","I","K"],["K","H","I","J"],["J","K","I","H"],["K","I","H","J"],["J","H","K","I"],["I","K","J","H"],["I","K","J","H"],["I","J","K","H"]]
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify(["H"])
+
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 4 candidates, 13 votes - Ranked Pairs");  
+
+    assert(function (cb) {
+        var _answers = {"44Yf9JjdL+25xyVrlv13SQab3Llx1Edyh0h4W8yFRGk=|4i1a0d8besa":{"msg":{"51nu46q526s":["H","I","J","K"],"_uid":"4i1a0d8besa","_time":1680643521926,"_hash":"WcmdpB3iDjHaVCiR844SLNcXNN6z8SOqzDCt9QbhoxhyLsP1CcNDmaGWhndVWnT2"},"hash":"WcmdpB3iDjHaVCiR844SLNcXNN6z8SOqzDCt9QbhoxhyLsP1CcNDmaGWhndVWnT2","time":1680643521926},"qhSqj2iIyFKA2UiipLxyWsybBbUu5sKWyIrUo/q5YDw=|3id6qekiv1h":{"msg":{"_uid":"3id6qekiv1h","_time":1680643559420,"_hash":"QR4mxsQoKb6SkaZZAbxZ4YyGK5yu2xqc8Z8MPFlTxQSUhg6XSGZzi4bNA+Q5I8A/"},"hash":"QR4mxsQoKb6SkaZZAbxZ4YyGK5yu2xqc8Z8MPFlTxQSUhg6XSGZzi4bNA+Q5I8A/","time":1680643559420},"mlRxie7OEDkqbF1X1c178p4yPh/g0+ZpUfhCXiYkqVY=|44r89gc710q":{"msg":{"51nu46q526s":["I","K","H","J"],"_uid":"44r89gc710q","_time":1680643771614,"_hash":"gCAVdvMr+ftWida0Au5QhM3Hr6DY37InIyeCwlo+hXHHEs75AZ47jS5ETgg+0nTC"},"hash":"gCAVdvMr+ftWida0Au5QhM3Hr6DY37InIyeCwlo+hXHHEs75AZ47jS5ETgg+0nTC","time":1680643771614},"TKmxMFaeKmHbSn5logEAzUnmNFA29XCoS58WQ+CjUgk=|ip2sjdk0d5":{"msg":{"51nu46q526s":["H","I","J","K"],"_uid":"ip2sjdk0d5","_time":1680643819623,"_hash":"UcFaJZKsj9P03iUv3r4k27tb+cC7suVH9hnL6YkTo3W9OftaCIYLnWhm4WdZ5n7q"},"hash":"UcFaJZKsj9P03iUv3r4k27tb+cC7suVH9hnL6YkTo3W9OftaCIYLnWhm4WdZ5n7q","time":1680643819623},"ZtOsJo23EAw2G/cB+jLHyLx5BfHw3RDVc8LDOv834R8=|1npd8sjbkts":{"msg":{"_uid":"1npd8sjbkts","_time":1680644213562,"_hash":"Tryu1aEbgkjjfS3w87KvonEvkuQ8iLyQ1/H1NTrapDRRe2Wy8AN1u2waEMY3D19P"},"hash":"Tryu1aEbgkjjfS3w87KvonEvkuQ8iLyQ1/H1NTrapDRRe2Wy8AN1u2waEMY3D19P","time":1680644213562},"bUPOx08ja9qh5G88o0OvHqH34UIfozKBdABbMM0Gll8=|3dt1klghi39":{"msg":{"51nu46q526s":["J","K","I","H"],"_uid":"3dt1klghi39","_time":1680692970797,"_hash":"zcWZPHsfRENVDvsHO7AtKfy9JwlX4JZ4vAXj7zHq8JncEDE3tRJCBFg9DfFrXUaQ"},"hash":"zcWZPHsfRENVDvsHO7AtKfy9JwlX4JZ4vAXj7zHq8JncEDE3tRJCBFg9DfFrXUaQ","time":1680692970797}}
+        var opts = {"values":[{"uid":"3vkp036vl76","v":"H"},{"uid":"1mtirujeook","v":"I"},{"uid":"5n31irpab5p","v":"J"},{"uid":"4cqdkqe0tad","v":"K"}]}
+        var uid = "51nu46q526s"
+        var form ={"51nu46q526s":{"condorcetmethod":"schulze","opts":{"values":[{"uid":"3vkp036vl76","v":"H"},{"uid":"1mtirujeook","v":"I"},{"uid":"5n31irpab5p","v":"J"},{"uid":"4cqdkqe0tad","v":"K"}]},"q":"Your question here?","type":"sort"}}
+        var optionArray = ["H","I","J","K"]
+        var listOfLists =[["H","I","J","K"],["I","K","H","J"],["H","I","J","K"],["J","K","I","H"]]
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify(["H", "I"])
+
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 4 candidates, 4 votes - Schulze");  
+
+    assert(function (cb) {
+        var _answers = {"44Yf9JjdL+25xyVrlv13SQab3Llx1Edyh0h4W8yFRGk=|4i1a0d8besa":{"msg":{"51nu46q526s":["H","I","J","K"],"_uid":"4i1a0d8besa","_time":1680643521926,"_hash":"WcmdpB3iDjHaVCiR844SLNcXNN6z8SOqzDCt9QbhoxhyLsP1CcNDmaGWhndVWnT2"},"hash":"WcmdpB3iDjHaVCiR844SLNcXNN6z8SOqzDCt9QbhoxhyLsP1CcNDmaGWhndVWnT2","time":1680643521926},"qhSqj2iIyFKA2UiipLxyWsybBbUu5sKWyIrUo/q5YDw=|3id6qekiv1h":{"msg":{"_uid":"3id6qekiv1h","_time":1680643559420,"_hash":"QR4mxsQoKb6SkaZZAbxZ4YyGK5yu2xqc8Z8MPFlTxQSUhg6XSGZzi4bNA+Q5I8A/"},"hash":"QR4mxsQoKb6SkaZZAbxZ4YyGK5yu2xqc8Z8MPFlTxQSUhg6XSGZzi4bNA+Q5I8A/","time":1680643559420},"mlRxie7OEDkqbF1X1c178p4yPh/g0+ZpUfhCXiYkqVY=|44r89gc710q":{"msg":{"51nu46q526s":["I","K","H","J"],"_uid":"44r89gc710q","_time":1680643771614,"_hash":"gCAVdvMr+ftWida0Au5QhM3Hr6DY37InIyeCwlo+hXHHEs75AZ47jS5ETgg+0nTC"},"hash":"gCAVdvMr+ftWida0Au5QhM3Hr6DY37InIyeCwlo+hXHHEs75AZ47jS5ETgg+0nTC","time":1680643771614},"TKmxMFaeKmHbSn5logEAzUnmNFA29XCoS58WQ+CjUgk=|ip2sjdk0d5":{"msg":{"51nu46q526s":["H","I","J","K"],"_uid":"ip2sjdk0d5","_time":1680643819623,"_hash":"UcFaJZKsj9P03iUv3r4k27tb+cC7suVH9hnL6YkTo3W9OftaCIYLnWhm4WdZ5n7q"},"hash":"UcFaJZKsj9P03iUv3r4k27tb+cC7suVH9hnL6YkTo3W9OftaCIYLnWhm4WdZ5n7q","time":1680643819623},"ZtOsJo23EAw2G/cB+jLHyLx5BfHw3RDVc8LDOv834R8=|1npd8sjbkts":{"msg":{"_uid":"1npd8sjbkts","_time":1680644213562,"_hash":"Tryu1aEbgkjjfS3w87KvonEvkuQ8iLyQ1/H1NTrapDRRe2Wy8AN1u2waEMY3D19P"},"hash":"Tryu1aEbgkjjfS3w87KvonEvkuQ8iLyQ1/H1NTrapDRRe2Wy8AN1u2waEMY3D19P","time":1680644213562},"bUPOx08ja9qh5G88o0OvHqH34UIfozKBdABbMM0Gll8=|3dt1klghi39":{"msg":{"51nu46q526s":["J","K","I","H"],"_uid":"3dt1klghi39","_time":1680692970797,"_hash":"zcWZPHsfRENVDvsHO7AtKfy9JwlX4JZ4vAXj7zHq8JncEDE3tRJCBFg9DfFrXUaQ"},"hash":"zcWZPHsfRENVDvsHO7AtKfy9JwlX4JZ4vAXj7zHq8JncEDE3tRJCBFg9DfFrXUaQ","time":1680692970797}}
+        var opts = {"values":[{"uid":"3vkp036vl76","v":"H"},{"uid":"1mtirujeook","v":"I"},{"uid":"5n31irpab5p","v":"J"},{"uid":"4cqdkqe0tad","v":"K"}]}
+        var uid = "51nu46q526s"
+        var form ={"51nu46q526s":{"condorcetmethod":"schulze","opts":{"values":[{"uid":"3vkp036vl76","v":"H"},{"uid":"1mtirujeook","v":"I"},{"uid":"5n31irpab5p","v":"J"},{"uid":"4cqdkqe0tad","v":"K"}]},"q":"Your question here?","type":"sort"}}
+        var optionArray = ["H","I","J","K"]
+        var listOfLists =[["H","I","J","K"],["I","K","H","J"],["H","I","J","K"],["J","K","I","H"]]
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify(["H", "I"])
+
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 4 candidates, 4 votes - Ranked Pairs");  
+
+    assert(function (cb) {
+        var _answers = {"3W07F9jVam8MiaX0NZZTI66GxClsdL5mOO+TJ8JJxWc=|6n9v5b0tgoe":{"msg":{"47nvphi67mf":["I","J","H","K"],"_uid":"6n9v5b0tgoe","_time":1680713369905,"_hash":"SF6yPOMHFAtJakkQLJNCnZKOaizUBzZQ8LHGk49/HakUxmiACal2Zk/eHZXWSCWl"},"hash":"SF6yPOMHFAtJakkQLJNCnZKOaizUBzZQ8LHGk49/HakUxmiACal2Zk/eHZXWSCWl","time":1680713369905},"igIpdO4t+3NUz71Lro0rak/vnETfjJdgewzNB2HpQAw=|55t8n89ht6p":{"msg":{"47nvphi67mf":["H","K","J","I"],"_uid":"55t8n89ht6p","_time":1681042330253,"_hash":"7aLd5yPtbmtJlaiRz2/vydel882KwC8DTwhD0aitI/AduyyI8A/zm0AQ3805GwGg"},"hash":"7aLd5yPtbmtJlaiRz2/vydel882KwC8DTwhD0aitI/AduyyI8A/zm0AQ3805GwGg","time":1681042330253},"xmjNpxMoy5hmdBh8qeeffeBT2X0dSahoIQUOimW39RI=|6h53t3s92ui":{"msg":{"47nvphi67mf":["H","J","K","I"],"_uid":"6h53t3s92ui","_time":1681042535649,"_hash":"3hbcSb+HmenP3zO+zXkzalHkfs3M2cg1UoFfArgHHru2OIznhAwKgN7veXc7dOnQ"},"hash":"3hbcSb+HmenP3zO+zXkzalHkfs3M2cg1UoFfArgHHru2OIznhAwKgN7veXc7dOnQ","time":1681042535649},"apFfNxra9Qd0gHx4wDoBIDT/aBnb3Rqzc+kaxRD8EBs=|4u27266gqp8":{"msg":{"47nvphi67mf":["K","J","I","H"],"_uid":"4u27266gqp8","_time":1681042567437,"_hash":"AXSlah8a2m+s/IQK9poMmg32vBQFExz8GqweUtQ86kFfJX5w9vmenkSmJTIPmmCQ"},"hash":"AXSlah8a2m+s/IQK9poMmg32vBQFExz8GqweUtQ86kFfJX5w9vmenkSmJTIPmmCQ","time":1681042567437},"RuYP2XRGujxTy1CDWPJTOfPokSqFY/5U6JT2nv83HwE=|7q94ctdudpr":{"msg":{"47nvphi67mf":["I","K","J","H"],"_uid":"7q94ctdudpr","_time":1681042678047,"_hash":"OGEOeu+W5fN7OIFeNilqfzf5tspIp5u3MkJM0mrntEhJRbR7aZfyE4RlRgNOp84J"},"hash":"OGEOeu+W5fN7OIFeNilqfzf5tspIp5u3MkJM0mrntEhJRbR7aZfyE4RlRgNOp84J","time":1681042678047}}
+        var opts = {"values":[{"uid":"6hggv459em6","v":"H"},{"uid":"2komjrerjjc","v":"I"},{"uid":"12d7pshc5ip","v":"J"},{"uid":"4u9jihh9u8k","v":"K"}]}
+        var uid = "47nvphi67mf"
+        var optionArray = ["H","I","J","K"]
+        var form = {"47nvphi67mf":{"opts":{"values":[{"uid":"6hggv459em6","v":"H"},{"uid":"2komjrerjjc","v":"I"},{"uid":"12d7pshc5ip","v":"J"},{"uid":"4u9jihh9u8k","v":"K"}]},"type":"sort","condorcetmethod":"schulze"}}
+        var listOfLists = [["I","J","H","K"],["H","K","J","I"],["H","J","K","I"],["K","J","I","H"],["I","K","J","H"]]
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify([])
+
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 4 candidates, 5 votes - Schulze");  
+
+    assert(function (cb) {
+        var _answers = {"3W07F9jVam8MiaX0NZZTI66GxClsdL5mOO+TJ8JJxWc=|6n9v5b0tgoe":{"msg":{"47nvphi67mf":["I","J","H","K"],"_uid":"6n9v5b0tgoe","_time":1680713369905,"_hash":"SF6yPOMHFAtJakkQLJNCnZKOaizUBzZQ8LHGk49/HakUxmiACal2Zk/eHZXWSCWl"},"hash":"SF6yPOMHFAtJakkQLJNCnZKOaizUBzZQ8LHGk49/HakUxmiACal2Zk/eHZXWSCWl","time":1680713369905},"igIpdO4t+3NUz71Lro0rak/vnETfjJdgewzNB2HpQAw=|55t8n89ht6p":{"msg":{"47nvphi67mf":["H","K","J","I"],"_uid":"55t8n89ht6p","_time":1681042330253,"_hash":"7aLd5yPtbmtJlaiRz2/vydel882KwC8DTwhD0aitI/AduyyI8A/zm0AQ3805GwGg"},"hash":"7aLd5yPtbmtJlaiRz2/vydel882KwC8DTwhD0aitI/AduyyI8A/zm0AQ3805GwGg","time":1681042330253},"xmjNpxMoy5hmdBh8qeeffeBT2X0dSahoIQUOimW39RI=|6h53t3s92ui":{"msg":{"47nvphi67mf":["H","J","K","I"],"_uid":"6h53t3s92ui","_time":1681042535649,"_hash":"3hbcSb+HmenP3zO+zXkzalHkfs3M2cg1UoFfArgHHru2OIznhAwKgN7veXc7dOnQ"},"hash":"3hbcSb+HmenP3zO+zXkzalHkfs3M2cg1UoFfArgHHru2OIznhAwKgN7veXc7dOnQ","time":1681042535649},"apFfNxra9Qd0gHx4wDoBIDT/aBnb3Rqzc+kaxRD8EBs=|4u27266gqp8":{"msg":{"47nvphi67mf":["K","J","I","H"],"_uid":"4u27266gqp8","_time":1681042567437,"_hash":"AXSlah8a2m+s/IQK9poMmg32vBQFExz8GqweUtQ86kFfJX5w9vmenkSmJTIPmmCQ"},"hash":"AXSlah8a2m+s/IQK9poMmg32vBQFExz8GqweUtQ86kFfJX5w9vmenkSmJTIPmmCQ","time":1681042567437},"RuYP2XRGujxTy1CDWPJTOfPokSqFY/5U6JT2nv83HwE=|7q94ctdudpr":{"msg":{"47nvphi67mf":["I","K","J","H"],"_uid":"7q94ctdudpr","_time":1681042678047,"_hash":"OGEOeu+W5fN7OIFeNilqfzf5tspIp5u3MkJM0mrntEhJRbR7aZfyE4RlRgNOp84J"},"hash":"OGEOeu+W5fN7OIFeNilqfzf5tspIp5u3MkJM0mrntEhJRbR7aZfyE4RlRgNOp84J","time":1681042678047}}
+        var opts = {"values":[{"uid":"6hggv459em6","v":"H"},{"uid":"2komjrerjjc","v":"I"},{"uid":"12d7pshc5ip","v":"J"},{"uid":"4u9jihh9u8k","v":"K"}]}
+        var uid = "47nvphi67mf"
+        var optionArray = ["H","I","J","K"]
+        var form = {"47nvphi67mf":{"opts":{"values":[{"uid":"6hggv459em6","v":"H"},{"uid":"2komjrerjjc","v":"I"},{"uid":"12d7pshc5ip","v":"J"},{"uid":"4u9jihh9u8k","v":"K"}]},"type":"sort","condorcetmethod":"ranked"}}
+        var listOfLists = [["I","J","H","K"],["H","K","J","I"],["H","J","K","I"],["K","J","I","H"],["I","K","J","H"]]
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify([])
+
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 4 candidates, 5 votes - Ranked Pairs");  
+
+    assert(function (cb) {
+        var _answers = {"HPGnFy2rrs6jnYcrwFV8ZzovC9wd9aWC1qg0uZ2O22U=|1atgtclbsf4":{"msg":{"3lfhpn08d91":["H","I","J","K","L","M","N"],"_uid":"1atgtclbsf4","_time":1681568806873,"_hash":"OpVK4UksFvVnRgsuYWgAK4OeT9MR5c189T9yuj3Itr+Q+wTZ0tLz0GaffQD2qQh4"},"hash":"OpVK4UksFvVnRgsuYWgAK4OeT9MR5c189T9yuj3Itr+Q+wTZ0tLz0GaffQD2qQh4","time":1681568806873},"v1JFwzjvxt3X8LrGv8bZXBOZwM98jxD2Tw87UrfexD8=|1g2ctgtffv6":{"msg":{"3lfhpn08d91":["N","M","J","K","H","I","L"],"_uid":"1g2ctgtffv6","_time":1681568926600,"_hash":"teOmfTUb0cYE8qfYktdxNaUHN4XkufGrAXWLuAMT+3qRr/krq1r1Y65M+RVaESae"},"hash":"teOmfTUb0cYE8qfYktdxNaUHN4XkufGrAXWLuAMT+3qRr/krq1r1Y65M+RVaESae","time":1681568926600},"i2YTGH7TvopuxOVHyDTzRmZbHsUtlJ/A3nVgZ+yavm8=|43e2h29aedb":{"msg":{"3lfhpn08d91":["K","L","M","N","I","J","H"],"_uid":"43e2h29aedb","_time":1681568964692,"_hash":"H5Qj5h4ObrHKKROICuuydFvMEnlsINPX+bicqWWbr+7mYYJr46fMOWpKW9vr4dQ1"},"hash":"H5Qj5h4ObrHKKROICuuydFvMEnlsINPX+bicqWWbr+7mYYJr46fMOWpKW9vr4dQ1","time":1681568964692},"WUrMHAvDx+he11SMp0Q8ELqh1I6bW2IC5nSdnbhUD2U=|30asm3vlu55":{"msg":{"3lfhpn08d91":["H","M","L","K","I","J","N"],"_uid":"30asm3vlu55","_time":1681569094752,"_hash":"sHJQ805YDqEFclLLmDnZRrp4syeUIOWqdeem1ShObVtLeCkZ99k68b9a+uHGvYVb"},"hash":"sHJQ805YDqEFclLLmDnZRrp4syeUIOWqdeem1ShObVtLeCkZ99k68b9a+uHGvYVb","time":1681569094752}}
+        var opts = {"values":[{"uid":"674sg3t7hpg","v":"H"},{"uid":"7fcgpg9iqga","v":"I"},{"uid":"2uqjmi2nsro","v":"J"},{"uid":"5gg447a5r5h","v":"K"},{"uid":"1i868f9au90","v":"L"},{"uid":"4t8g7f8dm3v","v":"M"},{"uid":"6ukb93ghagr","v":"N"}]}
+        var uid = "3lfhpn08d91"
+        var form = {"3lfhpn08d91":{"condorcetmethod":"schulze","opts":{"values":[{"uid":"674sg3t7hpg","v":"H"},{"uid":"7fcgpg9iqga","v":"I"},{"uid":"2uqjmi2nsro","v":"J"},{"uid":"5gg447a5r5h","v":"K"},{"uid":"1i868f9au90","v":"L"},{"uid":"4t8g7f8dm3v","v":"M"},{"uid":"6ukb93ghagr","v":"N"}]},"type":"sort"}}
+        var listOfLists = [["H","I","J","K","L","M","N"],["N","M","J","K","H","I","L"],["K","L","M","N","I","J","H"],["H","M","L","K","I","J","N"]]
+        var optionArray = ["H","I","J","K","L","M","N"]
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify(["H", "K", "M"])
+
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 7 candidates, 4 votes - Schulze");  
+
+    assert(function (cb) {
+        var _answers = {"HPGnFy2rrs6jnYcrwFV8ZzovC9wd9aWC1qg0uZ2O22U=|1atgtclbsf4":{"msg":{"3lfhpn08d91":["H","I","J","K","L","M","N"],"_uid":"1atgtclbsf4","_time":1681568806873,"_hash":"OpVK4UksFvVnRgsuYWgAK4OeT9MR5c189T9yuj3Itr+Q+wTZ0tLz0GaffQD2qQh4"},"hash":"OpVK4UksFvVnRgsuYWgAK4OeT9MR5c189T9yuj3Itr+Q+wTZ0tLz0GaffQD2qQh4","time":1681568806873},"v1JFwzjvxt3X8LrGv8bZXBOZwM98jxD2Tw87UrfexD8=|1g2ctgtffv6":{"msg":{"3lfhpn08d91":["N","M","J","K","H","I","L"],"_uid":"1g2ctgtffv6","_time":1681568926600,"_hash":"teOmfTUb0cYE8qfYktdxNaUHN4XkufGrAXWLuAMT+3qRr/krq1r1Y65M+RVaESae"},"hash":"teOmfTUb0cYE8qfYktdxNaUHN4XkufGrAXWLuAMT+3qRr/krq1r1Y65M+RVaESae","time":1681568926600},"i2YTGH7TvopuxOVHyDTzRmZbHsUtlJ/A3nVgZ+yavm8=|43e2h29aedb":{"msg":{"3lfhpn08d91":["K","L","M","N","I","J","H"],"_uid":"43e2h29aedb","_time":1681568964692,"_hash":"H5Qj5h4ObrHKKROICuuydFvMEnlsINPX+bicqWWbr+7mYYJr46fMOWpKW9vr4dQ1"},"hash":"H5Qj5h4ObrHKKROICuuydFvMEnlsINPX+bicqWWbr+7mYYJr46fMOWpKW9vr4dQ1","time":1681568964692},"WUrMHAvDx+he11SMp0Q8ELqh1I6bW2IC5nSdnbhUD2U=|30asm3vlu55":{"msg":{"3lfhpn08d91":["H","M","L","K","I","J","N"],"_uid":"30asm3vlu55","_time":1681569094752,"_hash":"sHJQ805YDqEFclLLmDnZRrp4syeUIOWqdeem1ShObVtLeCkZ99k68b9a+uHGvYVb"},"hash":"sHJQ805YDqEFclLLmDnZRrp4syeUIOWqdeem1ShObVtLeCkZ99k68b9a+uHGvYVb","time":1681569094752}}
+        var opts = {"values":[{"uid":"674sg3t7hpg","v":"H"},{"uid":"7fcgpg9iqga","v":"I"},{"uid":"2uqjmi2nsro","v":"J"},{"uid":"5gg447a5r5h","v":"K"},{"uid":"1i868f9au90","v":"L"},{"uid":"4t8g7f8dm3v","v":"M"},{"uid":"6ukb93ghagr","v":"N"}]}
+        var uid = "3lfhpn08d91"
+        var form = {"3lfhpn08d91":{"condorcetmethod":"ranked","opts":{"values":[{"uid":"674sg3t7hpg","v":"H"},{"uid":"7fcgpg9iqga","v":"I"},{"uid":"2uqjmi2nsro","v":"J"},{"uid":"5gg447a5r5h","v":"K"},{"uid":"1i868f9au90","v":"L"},{"uid":"4t8g7f8dm3v","v":"M"},{"uid":"6ukb93ghagr","v":"N"}]},"type":"sort"}}
+        var listOfLists = [["H","I","J","K","L","M","N"],["N","M","J","K","H","I","L"],["K","L","M","N","I","J","H"],["H","M","L","K","I","J","N"]]
+        var optionArray = ["H","I","J","K","L","M","N"]
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify(["H", "K", "M"])
+
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 7 candidates, 4 votes - Ranked Pairs");  
+
+    assert(function (cb) {
+        var _answers = {"3K9S8kV6tYGDtp5NUiQgXJPsCIEpbxZCbCLYIZSTgxg=|7i1lrkeg6n3":{"msg":{"2n3csc2haf9":["H","I","J","K","L","M"],"_uid":"7i1lrkeg6n3","_time":1681509031399,"_hash":"uWt5gUwaspvFWBOmA6dKfjUq6nHHb6BVq1/Y541CMPJd80NbHz5Q5vnrX/uyjQw/"},"hash":"uWt5gUwaspvFWBOmA6dKfjUq6nHHb6BVq1/Y541CMPJd80NbHz5Q5vnrX/uyjQw/","time":1681509031399},"oxnt14eIo9cKCXNkOMVxpCTpYXVs2WH4Lkvtsac0pwg=|59a717ashf3":{"msg":{"2n3csc2haf9":["H","J","I","M","L","K"],"_uid":"59a717ashf3","_time":1681509073345,"_hash":"wiQzaQNzR40kNNpiinET5rPskPUtEWk2VrBK0wCWt7apBKZ6VV4gjHXgMQjYgbAi"},"hash":"wiQzaQNzR40kNNpiinET5rPskPUtEWk2VrBK0wCWt7apBKZ6VV4gjHXgMQjYgbAi","time":1681509073345},"eJTxizgyVY/iuKlWfnoz8qkDCHJzSR6OJ3Ei51KhPVI=|29st9udvpc5":{"msg":{"2n3csc2haf9":["K","L","M","I","J","H"],"_uid":"29st9udvpc5","_time":1681509117027,"_hash":"WYZaIWbAvdN9n6NmlGv5IwGG/uspJApaM8HVOITDFw1SenzhhuCzjSi8K1myELLd"},"hash":"WYZaIWbAvdN9n6NmlGv5IwGG/uspJApaM8HVOITDFw1SenzhhuCzjSi8K1myELLd","time":1681509117027},"On0atQCvGd8Wq5AN16MlLarZGI8KHevWGpLACHl6vl8=|7jhhupqfjca":{"msg":{"2n3csc2haf9":["L","I","M","J","H","K"],"_uid":"7jhhupqfjca","_time":1681509152917,"_hash":"keshjQFnWyBV3zMlZlqmMDmyc3gve8qg6Marta4ScWl9N4VVvg92RoYXWAM8jpp5"},"hash":"keshjQFnWyBV3zMlZlqmMDmyc3gve8qg6Marta4ScWl9N4VVvg92RoYXWAM8jpp5","time":1681509152917}}
+        var opts = {"values":[{"uid":"31p0hol7tcr","v":"H"},{"uid":"3gu1lju1gbe","v":"I"},{"uid":"6hjcpk4oj49","v":"J"},{"uid":"e446uhqb6t","v":"K"},{"uid":"4pimmkrv0rk","v":"L"},{"uid":"5emh1hr9i6e","v":"M"}]}
+        var uid = "2n3csc2haf9"
+        var form = {"2n3csc2haf9":{"opts":{"values":[{"uid":"31p0hol7tcr","v":"H"},{"uid":"3gu1lju1gbe","v":"I"},{"uid":"6hjcpk4oj49","v":"J"},{"uid":"e446uhqb6t","v":"K"},{"uid":"4pimmkrv0rk","v":"L"},{"uid":"5emh1hr9i6e","v":"M"}]},"type":"sort","condorcetmethod":"schulze"}}
+        var listOfLists = [["H","I","J","K","L","M"],["H","J","I","M","L","K"],["K","L","M","I","J","H"],["L","I","M","J","H","K"]]
+        var optionArray = ["H","I","J","K","L","M"]
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify(["H", "I", "L"])
+
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 6 candidates, 4 votes - Schulze");  
+
+    assert(function (cb) {
+        var _answers = {"3K9S8kV6tYGDtp5NUiQgXJPsCIEpbxZCbCLYIZSTgxg=|7i1lrkeg6n3":{"msg":{"2n3csc2haf9":["H","I","J","K","L","M"],"_uid":"7i1lrkeg6n3","_time":1681509031399,"_hash":"uWt5gUwaspvFWBOmA6dKfjUq6nHHb6BVq1/Y541CMPJd80NbHz5Q5vnrX/uyjQw/"},"hash":"uWt5gUwaspvFWBOmA6dKfjUq6nHHb6BVq1/Y541CMPJd80NbHz5Q5vnrX/uyjQw/","time":1681509031399},"oxnt14eIo9cKCXNkOMVxpCTpYXVs2WH4Lkvtsac0pwg=|59a717ashf3":{"msg":{"2n3csc2haf9":["H","J","I","M","L","K"],"_uid":"59a717ashf3","_time":1681509073345,"_hash":"wiQzaQNzR40kNNpiinET5rPskPUtEWk2VrBK0wCWt7apBKZ6VV4gjHXgMQjYgbAi"},"hash":"wiQzaQNzR40kNNpiinET5rPskPUtEWk2VrBK0wCWt7apBKZ6VV4gjHXgMQjYgbAi","time":1681509073345},"eJTxizgyVY/iuKlWfnoz8qkDCHJzSR6OJ3Ei51KhPVI=|29st9udvpc5":{"msg":{"2n3csc2haf9":["K","L","M","I","J","H"],"_uid":"29st9udvpc5","_time":1681509117027,"_hash":"WYZaIWbAvdN9n6NmlGv5IwGG/uspJApaM8HVOITDFw1SenzhhuCzjSi8K1myELLd"},"hash":"WYZaIWbAvdN9n6NmlGv5IwGG/uspJApaM8HVOITDFw1SenzhhuCzjSi8K1myELLd","time":1681509117027},"On0atQCvGd8Wq5AN16MlLarZGI8KHevWGpLACHl6vl8=|7jhhupqfjca":{"msg":{"2n3csc2haf9":["L","I","M","J","H","K"],"_uid":"7jhhupqfjca","_time":1681509152917,"_hash":"keshjQFnWyBV3zMlZlqmMDmyc3gve8qg6Marta4ScWl9N4VVvg92RoYXWAM8jpp5"},"hash":"keshjQFnWyBV3zMlZlqmMDmyc3gve8qg6Marta4ScWl9N4VVvg92RoYXWAM8jpp5","time":1681509152917}}
+        var opts = {"values":[{"uid":"31p0hol7tcr","v":"H"},{"uid":"3gu1lju1gbe","v":"I"},{"uid":"6hjcpk4oj49","v":"J"},{"uid":"e446uhqb6t","v":"K"},{"uid":"4pimmkrv0rk","v":"L"},{"uid":"5emh1hr9i6e","v":"M"}]}
+        var uid = "2n3csc2haf9"
+        var form = {"2n3csc2haf9":{"opts":{"values":[{"uid":"31p0hol7tcr","v":"H"},{"uid":"3gu1lju1gbe","v":"I"},{"uid":"6hjcpk4oj49","v":"J"},{"uid":"e446uhqb6t","v":"K"},{"uid":"4pimmkrv0rk","v":"L"},{"uid":"5emh1hr9i6e","v":"M"}]},"type":"sort","condorcetmethod":"ranked"}}
+        var listOfLists = [["H","I","J","K","L","M"],["H","J","I","M","L","K"],["K","L","M","I","J","H"],["L","I","M","J","H","K"]]
+        var optionArray = ["H","I","J","K","L","M"]
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify(["H", "I", "L"])
+
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 6 candidates, 4 votes - Ranked Pairs");  
+
+    assert(function (cb) {
+        var _answers = {"uPsKCBZm459szjSk8QAFRv8/e8PPqUMlMO/5gsBL+RI=|9mh5cm44gf":{"msg":{"476l5onou7b":["I","H","K","J"],"_uid":"9mh5cm44gf","_time":1680621761370,"_hash":"f10mYauOvfHV/m9q+hLdXSq1ITGl5MTknJDoDVaDv1Vi5FwkBEl+dQJ2M6bsyoXH"},"hash":"f10mYauOvfHV/m9q+hLdXSq1ITGl5MTknJDoDVaDv1Vi5FwkBEl+dQJ2M6bsyoXH","time":1680621761370}, "CD3En5UdODx1H2ta2zter4OPwqbjWMaN1vj0HYne4j4=|2q0ad65qe37":{"msg":{"476l5onou7b":["I","H","J","K"],"_uid":"2q0ad65qe37","_time":1680621787994,"_hash":"d09chIZWk12/eY8qQO7q9tLhTKjXYrxVPBqhN665XPt/wrsnRuL1OBuPWnUytlMB"},"hash":"d09chIZWk12/eY8qQO7q9tLhTKjXYrxVPBqhN665XPt/wrsnRuL1OBuPWnUytlMB","time":1680621787994},
+        "yJgU1jOZaTHYrzQM+/4ax8xBzsR2RMzdQZdMyHO1Mns=|4s5t7bctcgg":{"msg":{"476l5onou7b":["I","K","H","J"],"_uid":"4s5t7bctcgg","_time":1680621809265,"_hash":"+Ez/hNKKVXpH2gasPFaOGMufJuQlPZ2S/T52CB4SRw3Yhu3pJGKl5aEIvtz+2pgs"},"hash":"+Ez/hNKKVXpH2gasPFaOGMufJuQlPZ2S/T52CB4SRw3Yhu3pJGKl5aEIvtz+2pgs","time":1680621809265},
+        "l7PXaqBvntgkAEAZ9+aq8GBZQ3NQUE1GJxdPk2RrAF4=|1sglk81ikjr":{"msg":{"476l5onou7b":["K","H","J","I"],"_uid":"1sglk81ikjr","_time":1680622487781,"_hash":"6lexIq9xczLYa0uDGMRJmKSNusnLt9AAXVnUHcxZlXJy40nRtZ28EejvHtGUl1Q9"},"hash":"6lexIq9xczLYa0uDGMRJmKSNusnLt9AAXVnUHcxZlXJy40nRtZ28EejvHtGUl1Q9","time":1680622487781},
+        "Iap8s5QBbrHhaR9hdn2l+WQiR4iRQhUtSep1HOkKLTw=|4v7r9d1gcau":{"msg":{"476l5onou7b":["K","J","H","I"],"_uid":"4v7r9d1gcau","_time":1680622514478,"_hash":"8eGwVmQqVWqHw+s2Cs7XEwdNkyA0R16Q/yHPsmpHp74+Zg+tfzwwlX9jqSVim9Mo"},"hash":"8eGwVmQqVWqHw+s2Cs7XEwdNkyA0R16Q/yHPsmpHp74+Zg+tfzwwlX9jqSVim9Mo","time":1680622514478},"bqD+83Sn0IkiNEIlmM2EG+lVHlfUWx4hXaASoyDn1xI=|4klohvjblv2":{"msg":{"476l5onou7b":["J","H","K","I"],"_uid":"4klohvjblv2","_time":1680622548988,"_hash":"SZbW7QFgYohF9ub/5nDZeiqK+Va9dYXbeKB8rn+resk/Ve66Vxpcj7yqm97fQHLn"},"hash":"SZbW7QFgYohF9ub/5nDZeiqK+Va9dYXbeKB8rn+resk/Ve66Vxpcj7yqm97fQHLn","time":1680622548988},"nC6qxNHT3w+HnRvB5BDLZvtLMKEug9EhXqwM+dgIpU4=|4bubr63ibdn":{"msg":{"476l5onou7b":["H","J","K","I"],"_uid":"4bubr63ibdn","_time":1680622577520,"_hash":"scBlg49DR7nW8vWeGn83qLNwSTyuC7qNTRwtfkC2tMwV5Zl3/H2fiVlUyvGIDZlx"},"hash":"scBlg49DR7nW8vWeGn83qLNwSTyuC7qNTRwtfkC2tMwV5Zl3/H2fiVlUyvGIDZlx","time":1680622577520},"g2GArwQ5P+Vi6AY1oxCWOTcPeJGcYz5ev6HTiyyP5FU=|70k27gjpvpp":{"msg":{"476l5onou7b":["H","K","J","I"],"_uid":"70k27gjpvpp","_time":1680635562832,"_hash":"sVHbb/S76dOqL27uy/ey7FQSZyPq4RGm2kxBzCOpr0WsGlClRtgq/j/jnwegYRP7"},"hash":"sVHbb/S76dOqL27uy/ey7FQSZyPq4RGm2kxBzCOpr0WsGlClRtgq/j/jnwegYRP7","time":1680635562832},"a1/8NHm3pOB0/wcs4DKKVegazxFx1gfzqfSL85s9xl0=|lgpdkas2c5":{"msg":{"476l5onou7b":["I","K","J","H"],"_uid":"lgpdkas2c5","_time":1680635589325,"_hash":"ftOs2WlCSOvaiqEfHoVPUdNZEkfpuf/qWUfHUlLov6KbS9ymLIIL++DPpy7010JA"},"hash":"ftOs2WlCSOvaiqEfHoVPUdNZEkfpuf/qWUfHUlLov6KbS9ymLIIL++DPpy7010JA","time":1680635589325},"i6nCrDCEEiLWcXTw0BsNjYVg0/utkFPGZxDGd6kRY3Q=|1t88pndrhqf":{"msg":{"476l5onou7b":["I","J","H","K"],"_uid":"1t88pndrhqf","_time":1680635610185,"_hash":"ry2PbM79VhVD9CZ5FIOQLSI+9nRC4SNbd4FbfywATxO2UcvmnWxPZIf2w6sbj/Y8"},"hash":"ry2PbM79VhVD9CZ5FIOQLSI+9nRC4SNbd4FbfywATxO2UcvmnWxPZIf2w6sbj/Y8","time":1680635610185},"T2xSs09f38m7vozpeJ6YgNYdcE83FznG1joqk2VHziw=|1i65duks12f":{"msg":{"476l5onou7b":["J","I","H","K"],"_uid":"1i65duks12f","_time":1680639763149,"_hash":"JJJmEuZ2hGh06LvnpPmnzlkf/WGlm1nNbmgfjLWESUxHUV5+6I1B3ul/xqDYF27X"},"hash":"JJJmEuZ2hGh06LvnpPmnzlkf/WGlm1nNbmgfjLWESUxHUV5+6I1B3ul/xqDYF27X","time":1680639763149}}
+        var opts = {"values":[{"uid":"14apbm7kkt9","v":"H"},{"uid":"3ehkepemfpl","v":"I"},{"uid":"5tp3iphk3rt","v":"J"},{"uid":"134okbmdltd","v":"K"}]}
+        var uid = "476l5onou7b"
+        var form = {"476l5onou7b":{"condorcetmethod":"schulze","opts":{"values":[{"uid":"14apbm7kkt9","v":"H"},{"uid":"3ehkepemfpl","v":"I"},{"uid":"5tp3iphk3rt","v":"J"},{"uid":"134okbmdltd","v":"K"}]},"type":"sort"}}
+        var listOfLists = [["I","H","K","J"],["I","H","J","K"],["I","K","H","J"],["K","H","J","I"],["K","J","H","I"],["J","H","K","I"],["H","J","K","I"],["H","K","J","I"],["I","K","J","H"],["I","J","H","K"],["J","I","H","K"]]
+        var optionArray = ["H","I","J","K"]
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify(["H", "I", "J"])
+
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 4 candidates, 11 votes - Schulze");  
+
+    assert(function (cb) {
+        var _answers = {"uPsKCBZm459szjSk8QAFRv8/e8PPqUMlMO/5gsBL+RI=|9mh5cm44gf":{"msg":{"476l5onou7b":["I","H","K","J"],"_uid":"9mh5cm44gf","_time":1680621761370,"_hash":"f10mYauOvfHV/m9q+hLdXSq1ITGl5MTknJDoDVaDv1Vi5FwkBEl+dQJ2M6bsyoXH"},"hash":"f10mYauOvfHV/m9q+hLdXSq1ITGl5MTknJDoDVaDv1Vi5FwkBEl+dQJ2M6bsyoXH","time":1680621761370}, "CD3En5UdODx1H2ta2zter4OPwqbjWMaN1vj0HYne4j4=|2q0ad65qe37":{"msg":{"476l5onou7b":["I","H","J","K"],"_uid":"2q0ad65qe37","_time":1680621787994,"_hash":"d09chIZWk12/eY8qQO7q9tLhTKjXYrxVPBqhN665XPt/wrsnRuL1OBuPWnUytlMB"},"hash":"d09chIZWk12/eY8qQO7q9tLhTKjXYrxVPBqhN665XPt/wrsnRuL1OBuPWnUytlMB","time":1680621787994},
+        "yJgU1jOZaTHYrzQM+/4ax8xBzsR2RMzdQZdMyHO1Mns=|4s5t7bctcgg":{"msg":{"476l5onou7b":["I","K","H","J"],"_uid":"4s5t7bctcgg","_time":1680621809265,"_hash":"+Ez/hNKKVXpH2gasPFaOGMufJuQlPZ2S/T52CB4SRw3Yhu3pJGKl5aEIvtz+2pgs"},"hash":"+Ez/hNKKVXpH2gasPFaOGMufJuQlPZ2S/T52CB4SRw3Yhu3pJGKl5aEIvtz+2pgs","time":1680621809265},
+        "l7PXaqBvntgkAEAZ9+aq8GBZQ3NQUE1GJxdPk2RrAF4=|1sglk81ikjr":{"msg":{"476l5onou7b":["K","H","J","I"],"_uid":"1sglk81ikjr","_time":1680622487781,"_hash":"6lexIq9xczLYa0uDGMRJmKSNusnLt9AAXVnUHcxZlXJy40nRtZ28EejvHtGUl1Q9"},"hash":"6lexIq9xczLYa0uDGMRJmKSNusnLt9AAXVnUHcxZlXJy40nRtZ28EejvHtGUl1Q9","time":1680622487781},
+        "Iap8s5QBbrHhaR9hdn2l+WQiR4iRQhUtSep1HOkKLTw=|4v7r9d1gcau":{"msg":{"476l5onou7b":["K","J","H","I"],"_uid":"4v7r9d1gcau","_time":1680622514478,"_hash":"8eGwVmQqVWqHw+s2Cs7XEwdNkyA0R16Q/yHPsmpHp74+Zg+tfzwwlX9jqSVim9Mo"},"hash":"8eGwVmQqVWqHw+s2Cs7XEwdNkyA0R16Q/yHPsmpHp74+Zg+tfzwwlX9jqSVim9Mo","time":1680622514478},"bqD+83Sn0IkiNEIlmM2EG+lVHlfUWx4hXaASoyDn1xI=|4klohvjblv2":{"msg":{"476l5onou7b":["J","H","K","I"],"_uid":"4klohvjblv2","_time":1680622548988,"_hash":"SZbW7QFgYohF9ub/5nDZeiqK+Va9dYXbeKB8rn+resk/Ve66Vxpcj7yqm97fQHLn"},"hash":"SZbW7QFgYohF9ub/5nDZeiqK+Va9dYXbeKB8rn+resk/Ve66Vxpcj7yqm97fQHLn","time":1680622548988},"nC6qxNHT3w+HnRvB5BDLZvtLMKEug9EhXqwM+dgIpU4=|4bubr63ibdn":{"msg":{"476l5onou7b":["H","J","K","I"],"_uid":"4bubr63ibdn","_time":1680622577520,"_hash":"scBlg49DR7nW8vWeGn83qLNwSTyuC7qNTRwtfkC2tMwV5Zl3/H2fiVlUyvGIDZlx"},"hash":"scBlg49DR7nW8vWeGn83qLNwSTyuC7qNTRwtfkC2tMwV5Zl3/H2fiVlUyvGIDZlx","time":1680622577520},"g2GArwQ5P+Vi6AY1oxCWOTcPeJGcYz5ev6HTiyyP5FU=|70k27gjpvpp":{"msg":{"476l5onou7b":["H","K","J","I"],"_uid":"70k27gjpvpp","_time":1680635562832,"_hash":"sVHbb/S76dOqL27uy/ey7FQSZyPq4RGm2kxBzCOpr0WsGlClRtgq/j/jnwegYRP7"},"hash":"sVHbb/S76dOqL27uy/ey7FQSZyPq4RGm2kxBzCOpr0WsGlClRtgq/j/jnwegYRP7","time":1680635562832},"a1/8NHm3pOB0/wcs4DKKVegazxFx1gfzqfSL85s9xl0=|lgpdkas2c5":{"msg":{"476l5onou7b":["I","K","J","H"],"_uid":"lgpdkas2c5","_time":1680635589325,"_hash":"ftOs2WlCSOvaiqEfHoVPUdNZEkfpuf/qWUfHUlLov6KbS9ymLIIL++DPpy7010JA"},"hash":"ftOs2WlCSOvaiqEfHoVPUdNZEkfpuf/qWUfHUlLov6KbS9ymLIIL++DPpy7010JA","time":1680635589325},"i6nCrDCEEiLWcXTw0BsNjYVg0/utkFPGZxDGd6kRY3Q=|1t88pndrhqf":{"msg":{"476l5onou7b":["I","J","H","K"],"_uid":"1t88pndrhqf","_time":1680635610185,"_hash":"ry2PbM79VhVD9CZ5FIOQLSI+9nRC4SNbd4FbfywATxO2UcvmnWxPZIf2w6sbj/Y8"},"hash":"ry2PbM79VhVD9CZ5FIOQLSI+9nRC4SNbd4FbfywATxO2UcvmnWxPZIf2w6sbj/Y8","time":1680635610185},"T2xSs09f38m7vozpeJ6YgNYdcE83FznG1joqk2VHziw=|1i65duks12f":{"msg":{"476l5onou7b":["J","I","H","K"],"_uid":"1i65duks12f","_time":1680639763149,"_hash":"JJJmEuZ2hGh06LvnpPmnzlkf/WGlm1nNbmgfjLWESUxHUV5+6I1B3ul/xqDYF27X"},"hash":"JJJmEuZ2hGh06LvnpPmnzlkf/WGlm1nNbmgfjLWESUxHUV5+6I1B3ul/xqDYF27X","time":1680639763149}}
+        var opts = {"values":[{"uid":"14apbm7kkt9","v":"H"},{"uid":"3ehkepemfpl","v":"I"},{"uid":"5tp3iphk3rt","v":"J"},{"uid":"134okbmdltd","v":"K"}]}
+        var uid = "476l5onou7b"
+        var form = {"476l5onou7b":{"condorcetmethod":"ranked","opts":{"values":[{"uid":"14apbm7kkt9","v":"H"},{"uid":"3ehkepemfpl","v":"I"},{"uid":"5tp3iphk3rt","v":"J"},{"uid":"134okbmdltd","v":"K"}]},"type":"sort"}}
+        var listOfLists = [["I","H","K","J"],["I","H","J","K"],["I","K","H","J"],["K","H","J","I"],["K","J","H","I"],["J","H","K","I"],["H","J","K","I"],["H","K","J","I"],["I","K","J","H"],["I","J","H","K"],["J","I","H","K"]]
+        var optionArray = ["H","I","J","K"]
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify(["H", "I", "J"])
+
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 4 candidates, 11 votes - Ranked Pairs");  
+
+    assert(function (cb) {
+        var _answers = {"nrWK2ao8+eOx2bH5eiRN/IEjISVyhGr/EOex5v75+zs=|775f8d6bpkk":{"msg":{"6k68uh55sje":["H","I","J"],"_uid":"775f8d6bpkk","_time":1681564571134,"_hash":"/Cpcp5XwZkpn0to3655jwfbeupdA2yfo0kxELTNcdkmBZSaOtpIs6GlHrFdRKilW"},"hash":"/Cpcp5XwZkpn0to3655jwfbeupdA2yfo0kxELTNcdkmBZSaOtpIs6GlHrFdRKilW","time":1681564571134}, "BKrBVKFcaj9puuzVm9ywFRprbyy5umzurZaAxB1gQ1o=|69h0imbpl68":{"msg":{"6k68uh55sje":["H","J","I"],"_uid":"69h0imbpl68","_time":1681564632044,"_hash":"en55cbanIJaMhfDKKaqjBZtwcT1fvZ0bZ7qAjVNxCYQpWIjLF2QvQ+8ttYRl3gvY"},"hash":"en55cbanIJaMhfDKKaqjBZtwcT1fvZ0bZ7qAjVNxCYQpWIjLF2QvQ+8ttYRl3gvY","time":1681564632044}, "o266rAZYYcndkql7+ewiz8J21l/khFhXcTEzqF3P70c=|2h678cjj3ge":{"msg":{"6k68uh55sje":["H","I","J"],"_uid":"2h678cjj3ge","_time":1681564668863,"_hash":"5bCwP2dcdJkvbMKVJrSMSWihZWk5LbgU3zEWM7KAgVh0n0FvbEuyU1UTeS/pVo/p"},"hash":"5bCwP2dcdJkvbMKVJrSMSWihZWk5LbgU3zEWM7KAgVh0n0FvbEuyU1UTeS/pVo/p","time":1681564668863}, "zmg/CjC3F7To5ljzXdiPM3wDuxW80+NAVd8iW3uJQhA=|5temr60s2ge":{"msg":{"6k68uh55sje":["J","H","I"],"_uid":"5temr60s2ge","_time":1681564706064,"_hash":"VEzxSCkwa156XAT0iAOaZs+Ou/gCpIYTAmtcTuUAVgnGt7wOGyu1BYQYd+9zopwv"},"hash":"VEzxSCkwa156XAT0iAOaZs+Ou/gCpIYTAmtcTuUAVgnGt7wOGyu1BYQYd+9zopwv","time":1681564706064}, "4p9p1hSTNo9YX7ICz5AzU15FDU13jaid67hzvqRuKXs=|1pfkdksafhc":{"msg":{"6k68uh55sje":["J","I","H"],"_uid":"1pfkdksafhc","_time":1681564731280,"_hash":"IVeb2gNNolQx2+eSzbFRe6UpHQw5k3pPTMXMVke8QNWlkGg+CBNbT97QgnO8gt2l"},"hash":"IVeb2gNNolQx2+eSzbFRe6UpHQw5k3pPTMXMVke8QNWlkGg+CBNbT97QgnO8gt2l","time":1681564731280},"+O8QZwcKU+xLpN60zrjhZtu0U3MFfG5/RH6Nk1xeHjw=|7o3rrpd2qut":{"msg":{"6k68uh55sje":["J","I","H"],"_uid":"7o3rrpd2qut","_time":1681564867941,"_hash":"/NqkTRwcc3+uXuLwCc0KGk8KmgZAuRgpM1IhOHzPq6X0zBVVstRNwCZSKae6YvCA"},"hash":"/NqkTRwcc3+uXuLwCc0KGk8KmgZAuRgpM1IhOHzPq6X0zBVVstRNwCZSKae6YvCA","time":1681564867941},
+        "kVmHV8AkKawlisyJ+7lpqV11IaSJN/fVQMrGQwRYJGo=|75uupriags3":{"msg":{"6k68uh55sje":["I","H","J"],"_uid":"75uupriags3","_time":1681564968983,"_hash":"nIckNlsRDiK9R4wyODah7kL9AcUDGn6+ybI26egRJN3FQo1EDNs4mHZQK5QgiQat"},"hash":"nIckNlsRDiK9R4wyODah7kL9AcUDGn6+ybI26egRJN3FQo1EDNs4mHZQK5QgiQat","time":1681564968983},"z0iE55YP3VOwa8PDfTvbKjPIP6W6zYeH5b+cvnwrejM=|12enpq7b72o":{"msg":{"6k68uh55sje":["I","J","H"],"_uid":"12enpq7b72o","_time":1681565031185,"_hash":"VvqT4umCeszARxIKyEFiwsI/Xi4OXPxDnwmZaIp8NYtqxfIkryaawmR4W8NRoYRH"},"hash":"VvqT4umCeszARxIKyEFiwsI/Xi4OXPxDnwmZaIp8NYtqxfIkryaawmR4W8NRoYRH","time":1681565031185}}
+        var opts = {"values":[{"uid":"7a5jt4jdn59","v":"H"},{"uid":"297t8tg4rme","v":"I"},{"uid":"43ae8cssfk8","v":"J"}]}
+        var uid = "6k68uh55sje"
+        var form = {"6k68uh55sje":{"opts":{"values":[{"uid":"7a5jt4jdn59","v":"H"},{"uid":"297t8tg4rme","v":"I"},{"uid":"43ae8cssfk8","v":"J"}]},"type":"sort","condorcetmethod":"schulze"}}
+        var listOfLists = [["H","I","J"],["H","J","I"],["H","I","J"],["J","H","I"],["J","I","H"],["J","I","H"],["I","H","J"],["I","J","H"]]
+        var optionArray = ["H","I","J"]
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify([])
+
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 3 candidates, 8 votes - Schulze");  
+
+    assert(function (cb) {
+        var _answers = {"nrWK2ao8+eOx2bH5eiRN/IEjISVyhGr/EOex5v75+zs=|775f8d6bpkk":{"msg":{"6k68uh55sje":["H","I","J"],"_uid":"775f8d6bpkk","_time":1681564571134,"_hash":"/Cpcp5XwZkpn0to3655jwfbeupdA2yfo0kxELTNcdkmBZSaOtpIs6GlHrFdRKilW"},"hash":"/Cpcp5XwZkpn0to3655jwfbeupdA2yfo0kxELTNcdkmBZSaOtpIs6GlHrFdRKilW","time":1681564571134}, "BKrBVKFcaj9puuzVm9ywFRprbyy5umzurZaAxB1gQ1o=|69h0imbpl68":{"msg":{"6k68uh55sje":["H","J","I"],"_uid":"69h0imbpl68","_time":1681564632044,"_hash":"en55cbanIJaMhfDKKaqjBZtwcT1fvZ0bZ7qAjVNxCYQpWIjLF2QvQ+8ttYRl3gvY"},"hash":"en55cbanIJaMhfDKKaqjBZtwcT1fvZ0bZ7qAjVNxCYQpWIjLF2QvQ+8ttYRl3gvY","time":1681564632044}, "o266rAZYYcndkql7+ewiz8J21l/khFhXcTEzqF3P70c=|2h678cjj3ge":{"msg":{"6k68uh55sje":["H","I","J"],"_uid":"2h678cjj3ge","_time":1681564668863,"_hash":"5bCwP2dcdJkvbMKVJrSMSWihZWk5LbgU3zEWM7KAgVh0n0FvbEuyU1UTeS/pVo/p"},"hash":"5bCwP2dcdJkvbMKVJrSMSWihZWk5LbgU3zEWM7KAgVh0n0FvbEuyU1UTeS/pVo/p","time":1681564668863}, "zmg/CjC3F7To5ljzXdiPM3wDuxW80+NAVd8iW3uJQhA=|5temr60s2ge":{"msg":{"6k68uh55sje":["J","H","I"],"_uid":"5temr60s2ge","_time":1681564706064,"_hash":"VEzxSCkwa156XAT0iAOaZs+Ou/gCpIYTAmtcTuUAVgnGt7wOGyu1BYQYd+9zopwv"},"hash":"VEzxSCkwa156XAT0iAOaZs+Ou/gCpIYTAmtcTuUAVgnGt7wOGyu1BYQYd+9zopwv","time":1681564706064}, "4p9p1hSTNo9YX7ICz5AzU15FDU13jaid67hzvqRuKXs=|1pfkdksafhc":{"msg":{"6k68uh55sje":["J","I","H"],"_uid":"1pfkdksafhc","_time":1681564731280,"_hash":"IVeb2gNNolQx2+eSzbFRe6UpHQw5k3pPTMXMVke8QNWlkGg+CBNbT97QgnO8gt2l"},"hash":"IVeb2gNNolQx2+eSzbFRe6UpHQw5k3pPTMXMVke8QNWlkGg+CBNbT97QgnO8gt2l","time":1681564731280},"+O8QZwcKU+xLpN60zrjhZtu0U3MFfG5/RH6Nk1xeHjw=|7o3rrpd2qut":{"msg":{"6k68uh55sje":["J","I","H"],"_uid":"7o3rrpd2qut","_time":1681564867941,"_hash":"/NqkTRwcc3+uXuLwCc0KGk8KmgZAuRgpM1IhOHzPq6X0zBVVstRNwCZSKae6YvCA"},"hash":"/NqkTRwcc3+uXuLwCc0KGk8KmgZAuRgpM1IhOHzPq6X0zBVVstRNwCZSKae6YvCA","time":1681564867941},
+        "kVmHV8AkKawlisyJ+7lpqV11IaSJN/fVQMrGQwRYJGo=|75uupriags3":{"msg":{"6k68uh55sje":["I","H","J"],"_uid":"75uupriags3","_time":1681564968983,"_hash":"nIckNlsRDiK9R4wyODah7kL9AcUDGn6+ybI26egRJN3FQo1EDNs4mHZQK5QgiQat"},"hash":"nIckNlsRDiK9R4wyODah7kL9AcUDGn6+ybI26egRJN3FQo1EDNs4mHZQK5QgiQat","time":1681564968983},"z0iE55YP3VOwa8PDfTvbKjPIP6W6zYeH5b+cvnwrejM=|12enpq7b72o":{"msg":{"6k68uh55sje":["I","J","H"],"_uid":"12enpq7b72o","_time":1681565031185,"_hash":"VvqT4umCeszARxIKyEFiwsI/Xi4OXPxDnwmZaIp8NYtqxfIkryaawmR4W8NRoYRH"},"hash":"VvqT4umCeszARxIKyEFiwsI/Xi4OXPxDnwmZaIp8NYtqxfIkryaawmR4W8NRoYRH","time":1681565031185}}
+        var opts = {"values":[{"uid":"7a5jt4jdn59","v":"H"},{"uid":"297t8tg4rme","v":"I"},{"uid":"43ae8cssfk8","v":"J"}]}
+        var uid = "6k68uh55sje"
+        var form = {"6k68uh55sje":{"opts":{"values":[{"uid":"7a5jt4jdn59","v":"H"},{"uid":"297t8tg4rme","v":"I"},{"uid":"43ae8cssfk8","v":"J"}]},"type":"sort","condorcetmethod":"ranked"}}
+        var listOfLists = [["H","I","J"],["H","J","I"],["H","I","J"],["J","H","I"],["J","I","H"],["J","I","H"],["I","H","J"],["I","J","H"]]
+        var optionArray = ["H","I","J"]
+        var result = JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)[0]) === JSON.stringify([])
+
+        cb(result);
+    }, "showCondorcetWinner: Check if correct winner calculated with 3 candidates, 8 votes - Ranked Pairs");  
+
 
     assert.run(function (state) {
         var errors = state.errors;
         var failed = errors.length;
         answers = ''
         Messages.assert_numberOfTestsPassed = "{0} / {1} tests passed.";
-        // console.log(obj.output)
-        console.log(errors)
         var statusClass = failed? 'failure': 'success';
         $('body').prepend(h('div.report.' + statusClass, [
             Messages._getKey('assert_numberOfTestsPassed', [

--- a/www/assert/main.js
+++ b/www/assert/main.js
@@ -801,13 +801,16 @@ define([
     }, "getSectionFromQ: ");  
 
     assert(function (cb) {
+        var _answers
+        var opts
+        var uid
+        var form
         var optionArray = []
         var listOfLists = []
-        var _answers
-        var uid
 
+        
 
-        var result = Condorcet.pickMethod(optionArray, listOfLists, _answers, uid)
+        var result = Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)
 
         cb(result);
     }, "getSectionFromQ: ");  

--- a/www/assert/main.js
+++ b/www/assert/main.js
@@ -562,35 +562,35 @@ define([
         cb(result);
     }, "getOptionValue: Checks if non-object rejected");  
 
-    //TO CHECK -- array not a valid result type
-    // assert(function (cb) {
-    //     var values = [{ uid: "1rrtjll2sl4", v: 1680688800000 }, { uid: "7dehmmrmac9", v: 'example text' }]
+    assert(function (cb) {
+        var values = [{ uid: "1rrtjll2sl4", v: 1680688800000 }, { uid: "7dehmmrmac9", v: 'example text' }]
 
-    //     var result = Form.extractValues(values) === [1680688800000,'example text']
+        var result = JSON.stringify(Form.extractValues(values)) === JSON.stringify([1680688800000,'example text'])
 
-    //     cb(result);
-    // }, "extractValues: Checks if option value array generated");  
+        cb(result);
+    }, "extractValues: Checks if option value array generated");  
 
-    // assert(function (cb) {
-    //     var values = { uid: "1rrtjll2sl4", v: 1680688800000 }
+    assert(function (cb) {
+        var values = { uid: "1rrtjll2sl4", v: 1680688800000 }
 
-    //     var result = Form.extractValues(values) === []
+        var result = JSON.stringify(Form.extractValues(values)) === JSON.stringify([])
 
-    //     cb(result);
-    // }, "extractValues: Checks if non-array rejected");  
+        cb(result);
+    }, "extractValues: Checks if non-array rejected");  
 
-    // assert(function (cb) {
-    //     var values = [{ uid: "1rrtjll2sl4", v: 1680688800000 }]
+    assert(function (cb) {
+        var values = [{ uid: "1rrtjll2sl4", v: 1680688800000 }]
 
-    //     var result = Form.extractValues(values) === [1680688800000]
+        var result = JSON.stringify(Form.extractValues(values)) === JSON.stringify([1680688800000])
 
-    //     cb(result);
-    // }, "extractValues: Checks if option value array generated with only one value");  
+        cb(result);
+    }, "extractValues: Checks if option value array generated with only one value");  
 
+    
     // assert(function (cb) {
     //     var answers = {"q+3dZT3CJ+XbkWhi5092symcW+IGJZPzd0RShYMEsHE=|35hfju0fsnu":{"msg":{"69rjecmhjb9":",mn,mn,mn,mn,mn","_uid":"35hfju0fsnu","_time":1681202916647,"_hash":"DbnusGXMDX663VM7D21tqQfz4pQIs7BKp6UpRBueoXtchIulIoqftOOWj7PpU6Lx"},"hash":"DbnusGXMDX663VM7D21tqQfz4pQIs7BKp6UpRBueoXtchIulIoqftOOWj7PpU6Lx","time":1681206767511},"SiTGBfCFwlcsLTNvufacxbc9X6mUpIoG9n1GAceMlA4=|66kj6s52omt":{"msg":{"69rjecmhjb9":"kjkjkjlkjlkjlkjlkjlkjlkjlkj","_uid":"66kj6s52omt","_time":1681205388977,"_hash":"TAoVobz7rNK3RSzkTpcaXRa47Eo63P0UvYjpGYSP1plgn8sq8iY1o4TdU4/LrnoE"},"hash":"TAoVobz7rNK3RSzkTpcaXRa47Eo63P0UvYjpGYSP1plgn8sq8iY1o4TdU4/LrnoE","time”:1681202916647},”NeDLoqFcwcKwd6rphOpEQ5X6aSlN9qGsvgi57kWKLA0=|1oq2djufaap":{"msg":{"69rjecmhjb9":"brrrrrrrrrr","_uid":"1oq2djufaap","_time":1681206767511,"_hash":"l/nJS20MK04js5WrPJCyZNF7WTmHXF9fdQXYRT0iY9DalgeetuBKnndKmwVG5kUr"},"hash":"l/nJS20MK04js5WrPJCyZNF7WTmHXF9fdQXYRT0iY9DalgeetuBKnndKmwVG5kUr","time":1681205388977}}}
         
-    //     var result = Form.getSortedKeys(answers) === ['SiTGBfCFwlcsLTNvufacxbc9X6mUpIoG9n1GAceMlA4=|66kj6s52omt','NeDLoqFcwcKwd6rphOpEQ5X6aSlN9qGsvgi57kWKLA0=|1oq2djufaap', 'q+3dZT3CJ+XbkWhi5092symcW+IGJZPzd0RShYMEsHE=|35hfju0fsnu']
+    //     var result = JSON.stringify(Form.getSortedKeys(answers)) === JSON.stringify(['SiTGBfCFwlcsLTNvufacxbc9X6mUpIoG9n1GAceMlA4=|66kj6s52omt','NeDLoqFcwcKwd6rphOpEQ5X6aSlN9qGsvgi57kWKLA0=|1oq2djufaap', 'q+3dZT3CJ+XbkWhi5092symcW+IGJZPzd0RShYMEsHE=|35hfju0fsnu'])
 
     //     cb(result);
     // }, "getSortedKeys: Checks if answer key array generated in correct order");  
@@ -604,20 +604,20 @@ define([
         cb(result);
     }, "getDay: Checks if correct day extracted from datetime");  
 
-    //TO CHECK -- array not a valid result type
-    // assert(function (cb) {
-    //     var dateOne = new Date('2023-01-23')
-    //     var dateTwo = new Date('2023-01-27')
+    assert(function (cb) {
+        var dateOne = new Date('2023-01-23')
+        var dateTwo = new Date('2023-01-27')
 
-    //     var result = Form.getDayArray(dateOne, dateTwo) === [1674428400000,1674514800000,1674601200000,1674687600000,1674774000000]
+        var result = JSON.stringify(Form.getDayArray(dateOne, dateTwo)) === JSON.stringify([1674428400000,1674514800000,1674601200000,1674687600000,1674774000000])
 
-    //     cb(result);
-    // }, "getDayArray: Checks if day array generated in correct order");  
+        cb(result);
+    }, "getDayArray: Checks if day array generated in correct order");  
+ 
 
     assert(function (cb) {
-        var answers = {"dnD12ORDDrY/tyN84dhBDznuJMxyPbXTk9qDygrqnmg=":{"726f3f4ulmd":{"msg":{"2":"Option 1","7mkcosm2rt0":"answer text","_uid":"726f3f4ulmd","_time":1681300220930,"_hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF"},"hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF","time":1681300220930}},"p6GuFDW8MBFm08qk8wYQtXHdKGhSBsdR5NgphX3dIyA=":{"ofu17vk29q":{"msg":{"2":"Option 2","7mkcosm2rt0":"example text","_uid":"ofu17vk29q","_time":1681300240916,"_hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ"},"hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ","time":1681300240916}},"O6+R4oi9CN2PIK/G9CcvZGWPaOnp+wdPnT4C87XLu0E=":{"7gvtagjf10j":{"msg":{"7mkcosm2rt0":"","_userdata":{"name":"example name"},"_uid":"7gvtagjf10j","_time":1681300260886,"_hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj"},"hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj","time":1681300260886}}}
+        var answers = {"NixYYkVPFCYUBh8LOQ1VchV7lfaTW4vgNiAKq89y+j0=":{"4oril7f8on3":{"msg":{"2":"Option 1","6v52hnop75":"text answer1","_uid":"4oril7f8on3","_time":1681813029990,"_hash":"Q6NjRGHWbmIIvEJ8RoLcTzfM+d/4NgHnT6xltkjK7Il8v6iIWSyS97gUHVKnRfZb"},"hash":"Q6NjRGHWbmIIvEJ8RoLcTzfM+d/4NgHnT6xltkjK7Il8v6iIWSyS97gUHVKnRfZb","time":1681813029990}},"Sf2e5dvPYQZYOcIhr4jxeO+fDvXiytggDtGx8Uan4mE=":{"2bpmiu5vbqu":{"msg":{"2":"Option 2","6v52hnop75":"text answer2","_userdata":{"name":"name1"},"_uid":"2bpmiu5vbqu","_time":1681813111981,"_hash":"hVYUczHSRsNr0lNqrqx7AYpV0eyDB2WK0ozVV482DMwdGU0BPLIBUmK6kkYhP71J"},"hash":"hVYUczHSRsNr0lNqrqx7AYpV0eyDB2WK0ozVV482DMwdGU0BPLIBUmK6kkYhP71J","time":1681813111981}}}
 
-        var result = JSON.stringify(Form.parseAnswers(answers)) == {"dnD12ORDDrY/tyN84dhBDznuJMxyPbXTk9qDygrqnmg=|726f3f4ulmd":{"726f3f4ulmd":{"msg":{"2":"Option 1","7mkcosm2rt0":"answer text","_uid":"726f3f4ulmd","_time":1681300220930,"_hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF"},"hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF","time":1681300220930}},"p6GuFDW8MBFm08qk8wYQtXHdKGhSBsdR5NgphX3dIyA=|ofu17vk29q":{"ofu17vk29q":{"msg":{"2":"Option 2","7mkcosm2rt0":"example text","_uid":"ofu17vk29q","_time":1681300240916,"_hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ"},"hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ","time":1681300240916}},"O6+R4oi9CN2PIK/G9CcvZGWPaOnp+wdPnT4C87XLu0E=|7gvtagjf10j":{"7gvtagjf10j":{"msg":{"7mkcosm2rt0":"","_userdata":{"name":"example name"},"_uid":"7gvtagjf10j","_time":1681300260886,"_hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj"},"hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj","time":1681300260886}}}
+        var result = JSON.stringify(Form.parseAnswers(answers)) === JSON.stringify({"NixYYkVPFCYUBh8LOQ1VchV7lfaTW4vgNiAKq89y+j0=|4oril7f8on3":{"msg":{"2":"Option 1","6v52hnop75":"text answer1","_uid":"4oril7f8on3","_time":1681813029990,"_hash":"Q6NjRGHWbmIIvEJ8RoLcTzfM+d/4NgHnT6xltkjK7Il8v6iIWSyS97gUHVKnRfZb"},"hash":"Q6NjRGHWbmIIvEJ8RoLcTzfM+d/4NgHnT6xltkjK7Il8v6iIWSyS97gUHVKnRfZb","time":1681813029990},"Sf2e5dvPYQZYOcIhr4jxeO+fDvXiytggDtGx8Uan4mE=|2bpmiu5vbqu":{"msg":{"2":"Option 2","6v52hnop75":"text answer2","_userdata":{"name":"name1"},"_uid":"2bpmiu5vbqu","_time":1681813111981,"_hash":"hVYUczHSRsNr0lNqrqx7AYpV0eyDB2WK0ozVV482DMwdGU0BPLIBUmK6kkYhP71J"},"hash":"hVYUczHSRsNr0lNqrqx7AYpV0eyDB2WK0ozVV482DMwdGU0BPLIBUmK6kkYhP71J","time":1681813111981}})
 
         cb(result);
     }, "parseAnswers: Checks if answers parsed correctly");  
@@ -626,97 +626,107 @@ define([
     // //no answers
     // //all kinds
 
-    // assert(function (cb) {
-    //     var answers = {"dnD12ORDDrY/tyN84dhBDznuJMxyPbXTk9qDygrqnmg=":{"726f3f4ulmd":{"msg":{"2":"Option 1","7mkcosm2rt0":"answer text","_uid":"726f3f4ulmd","_time":1681300220930,"_hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF"},"hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF","time":1681300220930}},"p6GuFDW8MBFm08qk8wYQtXHdKGhSBsdR5NgphX3dIyA=":{"ofu17vk29q":{"msg":{"2":"Option 2","7mkcosm2rt0":"example text","_uid":"ofu17vk29q","_time":1681300240916,"_hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ"},"hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ","time":1681300240916}},"O6+R4oi9CN2PIK/G9CcvZGWPaOnp+wdPnT4C87XLu0E=":{"7gvtagjf10j":{"msg":{"7mkcosm2rt0":"","_userdata":{"name":"example name"},"_uid":"7gvtagjf10j","_time":1681300260886,"_hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj"},"hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj","time":1681300260886}}}
+    assert(function (cb) {
+        var answers = {"dnD12ORDDrY/tyN84dhBDznuJMxyPbXTk9qDygrqnmg=":{"726f3f4ulmd":{"msg":{"2":"Option 1","7mkcosm2rt0":"answer text","_uid":"726f3f4ulmd","_time":1681300220930,"_hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF"},"hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF","time":1681300220930}},"p6GuFDW8MBFm08qk8wYQtXHdKGhSBsdR5NgphX3dIyA=":{"ofu17vk29q":{"msg":{"2":"Option 2","7mkcosm2rt0":"example text","_uid":"ofu17vk29q","_time":1681300240916,"_hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ"},"hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ","time":1681300240916}},"O6+R4oi9CN2PIK/G9CcvZGWPaOnp+wdPnT4C87XLu0E=":{"7gvtagjf10j":{"msg":{"7mkcosm2rt0":"","_userdata":{"name":"example name"},"_uid":"7gvtagjf10j","_time":1681300260886,"_hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj"},"hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj","time":1681300260886}}}
 
-    //     var result = Form.getAnswersLength(answers) === 3;
+        var result = Form.getAnswersLength(answers) === 3;
 
-    //     cb(result);
-    // }, "getOptionValue: Checks if non-object rejected");  
+        cb(result);
+    }, "getAnswersLength: Checks if answers length correct");  
 
-    // assert(function (cb) {
-    //     // var answers = {"dnD12ORDDrY/tyN84dhBDznuJMxyPbXTk9qDygrqnmg=":{"726f3f4ulmd":{"msg":{"2":"Option 1","7mkcosm2rt0":"answer text","_uid":"726f3f4ulmd","_time":1681300220930,"_hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF"},"hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF","time":1681300220930}},"p6GuFDW8MBFm08qk8wYQtXHdKGhSBsdR5NgphX3dIyA=":{"ofu17vk29q":{"msg":{"2":"Option 2","7mkcosm2rt0":"example text","_uid":"ofu17vk29q","_time":1681300240916,"_hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ"},"hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ","time":1681300240916}},"O6+R4oi9CN2PIK/G9CcvZGWPaOnp+wdPnT4C87XLu0E=":{"7gvtagjf10j":{"msg":{"7mkcosm2rt0":"","_userdata":{"name":"example name"},"_uid":"7gvtagjf10j","_time":1681300260886,"_hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj"},"hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj","time":1681300260886}}}
-    //     var uid = "66gk9ne3plg"
-    //     var items = [{ uid: "66gk9ne3plg", v: "Item 1" }, { uid: "66gk9ne3plg", v: "Item 1" }]
+    assert(function (cb) {
+        var uid = "66gk9ne3plg"
+        var items = [{ uid: "66gk9ne3plg", v: "Item 1" }, { uid: "66gk9ne3plg", v: "Item 1" }]
         
-    //     var result = Form.findItem(items, uid) === 'Item 1'
+        var result = Form.findItem(items, uid) === 'Item 1'
 
-    //     cb(result);
-    // }, "getOptionValue: Checks if non-object rejected");  
+        cb(result);
+    }, "findItem: Checks if correct answer value identified in object (by uid)");  
 
-    // assert(function (cb) {
+    assert(function (cb) {
 
-    //     var content = {"answers":{"anonymous":true,"channel":"f0c618aafe7071f8c239834793643d66","publicKey":"82gx8xzoV6bgHBQ1zoic57b2cjgxZ9zO2V67c2486ng=","validateKey":"in4+E1sKdZ+MHayQ5O2gJdMqi4Tvmk35/z/1HEqTr4M=","version":2},"form":{"1q086i8iuv0":{"opts":{"type":"text"},"type":"input"},"2de53antgns":{"opts":{"type":"text"},"type":"input"},"3nqrkethqre":{"opts":{"questions":["2de53antgns"],"when":[]},"type":"section"},"489ghit6aa6":{"opts":{"type":"text"},"type":"input"},"5l43527l18c":{"opts":{"maxLength":1000},"type":"textarea"},"5satfltfm3u":{"opts":{"type":"text"},"type":"input"}},"order":["5l43527l18c","489ghit6aa6","1q086i8iuv0","5satfltfm3u","3nqrkethqre"],"version":1}
+        var content = {"answers":{"anonymous":true,"channel":"f0c618aafe7071f8c239834793643d66","publicKey":"82gx8xzoV6bgHBQ1zoic57b2cjgxZ9zO2V67c2486ng=","validateKey":"in4+E1sKdZ+MHayQ5O2gJdMqi4Tvmk35/z/1HEqTr4M=","version":2},"form":{"1q086i8iuv0":{"opts":{"type":"text"},"type":"input"},"2de53antgns":{"opts":{"type":"text"},"type":"input"},"3nqrkethqre":{"opts":{"questions":["2de53antgns"],"when":[]},"type":"section"},"489ghit6aa6":{"opts":{"type":"text"},"type":"input"},"5l43527l18c":{"opts":{"maxLength":1000},"type":"textarea"},"5satfltfm3u":{"opts":{"type":"text"},"type":"input"}},"order":["5l43527l18c","489ghit6aa6","1q086i8iuv0","5satfltfm3u","3nqrkethqre"],"version":1}
 
-    //     var result = Form.getSections(content) === ["3nqrkethqre"]
+        var result = JSON.stringify(Form.getSections(content)) === JSON.stringify(["3nqrkethqre"])
 
-    //     cb(result);
-    // }, "getOptionValue: Checks if non-object rejected");  
+        cb(result);
+    }, "getSections: Checks if sections question type correctly identified (by uid)");  
 
-    // assert(function (cb) {
-    //     var content = {"answers":{"anonymous":true,"channel":"f0c618aafe7071f8c239834793643d66","publicKey":"82gx8xzoV6bgHBQ1zoic57b2cjgxZ9zO2V67c2486ng=","validateKey":"in4+E1sKdZ+MHayQ5O2gJdMqi4Tvmk35/z/1HEqTr4M=","version":2},"form":{"1q086i8iuv0":{"opts":{"type":"text"},"type":"input"},"2de53antgns":{"opts":{"type":"text"},"type":"input"},"3nqrkethqre":{"opts":{"questions":["2de53antgns"],"when":[]},"type":"section"},"489ghit6aa6":{"opts":{"type":"text"},"type":"input"},"5l43527l18c":{"opts":{"maxLength":1000},"type":"textarea"},"5satfltfm3u":{"opts":{"type":"text"},"type":"input"}},"order":["5l43527l18c","489ghit6aa6","1q086i8iuv0","5satfltfm3u","3nqrkethqre"],"version":1}
+    assert(function (cb) {
+        var content = {"answers":{"anonymous":true,"channel":"f0c618aafe7071f8c239834793643d66","publicKey":"82gx8xzoV6bgHBQ1zoic57b2cjgxZ9zO2V67c2486ng=","validateKey":"in4+E1sKdZ+MHayQ5O2gJdMqi4Tvmk35/z/1HEqTr4M=","version":2},"form":{"1q086i8iuv0":{"opts":{"type":"text"},"type":"input"},"2de53antgns":{"opts":{"type":"text"},"type":"input"},"3nqrkethqre":{"opts":{"questions":["2de53antgns"],"when":[]},"type":"section"},"489ghit6aa6":{"opts":{"type":"text"},"type":"input"},"5l43527l18c":{"opts":{"maxLength":1000},"type":"textarea"},"5satfltfm3u":{"opts":{"type":"text"},"type":"input"}},"order":["5l43527l18c","489ghit6aa6","1q086i8iuv0","5satfltfm3u","3nqrkethqre"],"version":1}
 
-    //     var result = Form.getFullOrder(content) === [ "5l43527l18c", "489ghit6aa6", "1q086i8iuv0", "5satfltfm3u", "3nqrkethqre", "2de53antgns" ]
+        var result = JSON.stringify(Form.getFullOrder(content)) === JSON.stringify([ "5l43527l18c", "489ghit6aa6", "1q086i8iuv0", "5satfltfm3u", "3nqrkethqre", "2de53antgns" ])
 
-    //     cb(result);
-    // }, "getOptionValue: Checks if non-object rejected");  
+        cb(result);
+    }, "getFullOrder: Checks if array of answer uids generated in correct order");  
 
-    // assert(function (cb) {
-    //     var answers = {"PIZkFh+x41UdYNXEEAAhzNRG2juhlH6bbvX9xw+KO0c=|2fkkqujbog4":{"msg":{"7bnj9a8okpn":{"values":{"Option 1":"1","Option 2":"0","Option 3":"0"}},"_uid":"2fkkqujbog4","_time":1681411078436,"_hash":"FbIr34E1A88dX9QXflyxwa/uLIKmucq0XYvuRQyNxfoJSN7fO4oh/KxxVekDXqAk"},"hash":"FbIr34E1A88dX9QXflyxwa/uLIKmucq0XYvuRQyNxfoJSN7fO4oh/KxxVekDXqAk","time":1681411078436}}
+    assert(function (cb) {
+        var answers = {"PIZkFh+x41UdYNXEEAAhzNRG2juhlH6bbvX9xw+KO0c=|2fkkqujbog4":{"msg":{"7bnj9a8okpn":{"values":{"Option 1":"1","Option 2":"0","Option 3":"0"}},"_uid":"2fkkqujbog4","_time":1681411078436,"_hash":"FbIr34E1A88dX9QXflyxwa/uLIKmucq0XYvuRQyNxfoJSN7fO4oh/KxxVekDXqAk"},"hash":"FbIr34E1A88dX9QXflyxwa/uLIKmucq0XYvuRQyNxfoJSN7fO4oh/KxxVekDXqAk","time":1681411078436}}
         
-    //     var uid = "7bnj9a8okpn"
+        var uid = "7bnj9a8okpn"
 
-    //     var filterCurve = false
+        var filterCurve = false
 
-    //     var result = Form.getBlockAnswers(answers, uid, filterCurve) === [{"curve":"PIZkFh+x41UdYNXEEAAhzNRG2juhlH6bbvX9xw+KO0c=","results":{"values":{"Option 1":"1","Option 2":"0","Option 3":"0"}},"time":1681411078436}]
+        var result = JSON.stringify(Form.getBlockAnswers(answers, uid, filterCurve)) === JSON.stringify([{"curve":"PIZkFh+x41UdYNXEEAAhzNRG2juhlH6bbvX9xw+KO0c=","results":{"values":{"Option 1":"1","Option 2":"0","Option 3":"0"}},"time":1681411078436}])
 
-    //     cb(result);
-    // }, "getOptionValue: Checks if non-object rejected");  
+        cb(result);
+    }, "getBlockAnswers: ");  
 
-    // assert(function (cb) {
-    //     var content = {"answers":{"anonymous":true,"channel":"dd879143bd4a49fd7e68f6c5109e4d9f","publicKey":"Ja4U/ESMGx/BjTTChbAZD+SFG0P+93o3F4XW6CJR0DA=","validateKey":"swNQf0LqJFWThBSE+iw8VryY2xId+QVcbn9XFeLNfXU=","version":2},"form":{"3e81recgc5g":{"opts":{"type":"text"},"type":"input"},"60tij442l02":{"opts":{"questions":["3e81recgc5g"],"when":[]},"type":"section"},"6bbmju7i65i":{"opts":{"type":"text"},"type":"input"}},"order":["6bbmju7i65i","60tij442l02"],"version":1}
+    assert(function (cb) {
+        var content = {"answers":{"anonymous":true,"channel":"dd879143bd4a49fd7e68f6c5109e4d9f","publicKey":"Ja4U/ESMGx/BjTTChbAZD+SFG0P+93o3F4XW6CJR0DA=","validateKey":"swNQf0LqJFWThBSE+iw8VryY2xId+QVcbn9XFeLNfXU=","version":2},"form":{"3e81recgc5g":{"opts":{"type":"text"},"type":"input"},"60tij442l02":{"opts":{"questions":["3e81recgc5g"],"when":[]},"type":"section"},"6bbmju7i65i":{"opts":{"type":"text"},"type":"input"}},"order":["6bbmju7i65i","60tij442l02"],"version":1}
         
-    //     var result = Form.getSections(content) === [ "60tij442l02" ]
+        var result = JSON.stringify(Form.getSections(content)) === JSON.stringify([ "60tij442l02" ])
 
-    //     cb(result);
-    // }, "getOptionValue: Checks if non-object rejected");  
+        cb(result);
+    }, "getSections: ");  
 
-    // assert(function (cb) {
-    //     // var answers = {"dnD12ORDDrY/tyN84dhBDznuJMxyPbXTk9qDygrqnmg=":{"726f3f4ulmd":{"msg":{"2":"Option 1","7mkcosm2rt0":"answer text","_uid":"726f3f4ulmd","_time":1681300220930,"_hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF"},"hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF","time":1681300220930}},"p6GuFDW8MBFm08qk8wYQtXHdKGhSBsdR5NgphX3dIyA=":{"ofu17vk29q":{"msg":{"2":"Option 2","7mkcosm2rt0":"example text","_uid":"ofu17vk29q","_time":1681300240916,"_hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ"},"hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ","time":1681300240916}},"O6+R4oi9CN2PIK/G9CcvZGWPaOnp+wdPnT4C87XLu0E=":{"7gvtagjf10j":{"msg":{"7mkcosm2rt0":"","_userdata":{"name":"example name"},"_uid":"7gvtagjf10j","_time":1681300260886,"_hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj"},"hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj","time":1681300260886}}}
-    //     var APP;
-    //     APP.formBlocks = [{"tag":{"jQuery360028827848464003571":{"events":{"keypress":[{"type":"keypress","origType":"keypress","guid":55,"namespace":""}],"change":[{"type":"change","origType":"change","guid":55,"namespace":""}]}}},"uid":"298095t8h92"},{"tag":{"jQuery360028827848464003571":{"events":{"keypress":[{"type":"keypress","origType":"keypress","guid":56,"namespace":""}],"change":[{"type":"change","origType":"change","guid":56,"namespace":""}]}}},"uid":"69rjecmhjb9"}]
-    //     var result = Form.getFormResults() === { "298095t8h92": "answer1", "69rjecmhjb9": "answer2" }
+    //CAN'T MOCK 'APP'
+    assert(function (cb) {
+        // var answers = {"dnD12ORDDrY/tyN84dhBDznuJMxyPbXTk9qDygrqnmg=":{"726f3f4ulmd":{"msg":{"2":"Option 1","7mkcosm2rt0":"answer text","_uid":"726f3f4ulmd","_time":1681300220930,"_hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF"},"hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF","time":1681300220930}},"p6GuFDW8MBFm08qk8wYQtXHdKGhSBsdR5NgphX3dIyA=":{"ofu17vk29q":{"msg":{"2":"Option 2","7mkcosm2rt0":"example text","_uid":"ofu17vk29q","_time":1681300240916,"_hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ"},"hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ","time":1681300240916}},"O6+R4oi9CN2PIK/G9CcvZGWPaOnp+wdPnT4C87XLu0E=":{"7gvtagjf10j":{"msg":{"7mkcosm2rt0":"","_userdata":{"name":"example name"},"_uid":"7gvtagjf10j","_time":1681300260886,"_hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj"},"hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj","time":1681300260886}}}
+        // var APP = {};
+        APP.formBlocks = [{"tag":{"jQuery360028827848464003571":{"events":{"keypress":[{"type":"keypress","origType":"keypress","guid":55,"namespace":""}],"change":[{"type":"change","origType":"change","guid":55,"namespace":""}]}}},"uid":"298095t8h92"},{"tag":{"jQuery360028827848464003571":{"events":{"keypress":[{"type":"keypress","origType":"keypress","guid":56,"namespace":""}],"change":[{"type":"change","origType":"change","guid":56,"namespace":""}]}}},"uid":"69rjecmhjb9"}]
+        console.log("YOOHOO", JSON.stringify(Form.getFormResults()))
+        var result = JSON.stringify(Form.getFormResults()) 
+        console.log("YUYIUYUY", result)
+        // === JSON.stringify({ "298095t8h92": "answer1", "69rjecmhjb9": "answer2" })
 
-    //     cb(result);
-    // }, "getOptionValue: Checks if non-object rejected");  
+        cb(result);
+    }, "getFormResults: ");  
+
 
     // assert(function (cb) {
     //     var content = {"answers":{"anonymous":true,"channel":"dd879143bd4a49fd7e68f6c5109e4d9f","publicKey":"Ja4U/ESMGx/BjTTChbAZD+SFG0P+93o3F4XW6CJR0DA=","validateKey":"swNQf0LqJFWThBSE+iw8VryY2xId+QVcbn9XFeLNfXU=","version":2},"form":{"3e81recgc5g":{"opts":{"type":"text"},"type":"input"},"60tij442l02":{"opts":{"questions":["3e81recgc5g"],"when":[]},"type":"section"},"6bbmju7i65i":{"opts":{"type":"text"},"type":"input"}},"order":["6bbmju7i65i","60tij442l02"],"version":1}
         
     //     var uid = "6bbmju7i65i"
 
-    //     var result = Form.getSectionFromQ(content, uid) === {"arr":["76nff13m2m2","6bbmju7i65i","60tij442l02"],"idx":0}
+    //     var result = JSON.stringify(Form.getSectionFromQ(content, uid)) 
+    //     // === JSON.stringify({"arr":["76nff13m2m2","6bbmju7i65i","60tij442l02"],"idx":0})
 
     //     cb(result);
-    // }, "getOptionValue: Checks if non-object rejected");  
+    // }, "getSectionFromQ: ");  
 
-    // assert(function (cb) {
-    //     var content = {"answers":{"anonymous":true,"channel":"dd879143bd4a49fd7e68f6c5109e4d9f","publicKey":"Ja4U/ESMGx/BjTTChbAZD+SFG0P+93o3F4XW6CJR0DA=","validateKey":"swNQf0LqJFWThBSE+iw8VryY2xId+QVcbn9XFeLNfXU=","version":2},"form":{"3e81recgc5g":{"opts":{"type":"text"},"type":"input"},"53g43utbomt":{"opts":{"type":"text"},"type":"input"},"60tij442l02":{"opts":{"questions":["3e81recgc5g"],"when":[]},"type":"section"},"78uh4r9n10u":{"opts":{"values":[{"uid":"384h23hpkcm","v":"Option 1"},{"uid":"3nnb01frfvl","v":"Option 2"}]},"type":"radio"},"3s5hqske4pc":{"opts":{"type":"text"},"type":"input"}},"order":["60tij442l02","78uh4r9n10u","53g43utbomt","3s5hqske4pc"],"version":1}
+    assert(function (cb) {
+        var content = {"answers":{"anonymous":true,"channel":"dd879143bd4a49fd7e68f6c5109e4d9f","publicKey":"Ja4U/ESMGx/BjTTChbAZD+SFG0P+93o3F4XW6CJR0DA=","validateKey":"swNQf0LqJFWThBSE+iw8VryY2xId+QVcbn9XFeLNfXU=","version":2},"form":{"3e81recgc5g":{"opts":{"type":"text"},"type":"input"},"53g43utbomt":{"opts":{"type":"text"},"type":"input"},"60tij442l02":{"opts":{"questions":["3e81recgc5g"],"when":[]},"type":"section"},"78uh4r9n10u":{"opts":{"values":[{"uid":"384h23hpkcm","v":"Option 1"},{"uid":"3nnb01frfvl","v":"Option 2"}]},"type":"radio"},"3s5hqske4pc":{"opts":{"type":"text"},"type":"input"}},"order":["60tij442l02","78uh4r9n10u","53g43utbomt","3s5hqske4pc"],"version":1}
         
-    //     var uid = "3s5hqske4rq"
+        var uid = "60tij442l02"
 
-    //     var result = Form.removeQuestion(content, uid) === true
+        Form.removeQuestion(content, uid) 
 
-    //     cb(result);
-    // }, "getOptionValue: Checks if non-object rejected");  
+        var result = JSON.stringify(content.order) === JSON.stringify(["78uh4r9n10u", "53g43utbomt", "3s5hqske4pc"])
+
+        cb(result);
+    }, "removeQuestion: ");  
 
     // assert(function (cb) {
+    //     APP.formBlocks = [{"tag":{"jQuery360028827848464003571":{"events":{"keypress":[{"type":"keypress","origType":"keypress","guid":55,"namespace":""}],"change":[{"type":"change","origType":"change","guid":55,"namespace":""}]}}},"uid":"298095t8h92"},{"tag":{"jQuery360028827848464003571":{"events":{"keypress":[{"type":"keypress","origType":"keypress","guid":56,"namespace":""}],"change":[{"type":"change","origType":"change","guid":56,"namespace":""}]}}},"uid":"69rjecmhjb9"}]
+    //     var block = {"opts":{"questions":["3e81recgc5g"],"when":[[{"is":1,"q":"30uco1e435n","uid":"4vvq79pi7s6","v":"Option 1"}]]},"type":"section"}
     //     // var answers = {"dnD12ORDDrY/tyN84dhBDznuJMxyPbXTk9qDygrqnmg=":{"726f3f4ulmd":{"msg":{"2":"Option 1","7mkcosm2rt0":"answer text","_uid":"726f3f4ulmd","_time":1681300220930,"_hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF"},"hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF","time":1681300220930}},"p6GuFDW8MBFm08qk8wYQtXHdKGhSBsdR5NgphX3dIyA=":{"ofu17vk29q":{"msg":{"2":"Option 2","7mkcosm2rt0":"example text","_uid":"ofu17vk29q","_time":1681300240916,"_hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ"},"hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ","time":1681300240916}},"O6+R4oi9CN2PIK/G9CcvZGWPaOnp+wdPnT4C87XLu0E=":{"7gvtagjf10j":{"msg":{"7mkcosm2rt0":"","_userdata":{"name":"example name"},"_uid":"7gvtagjf10j","_time":1681300260886,"_hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj"},"hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj","time":1681300260886}}}
-
-    //     var result = Form.checkCondition() === 
+    //     var result = JSON.stringify(Form.checkCondition(block)) 
+    //     console.log("WOOOO", result)
+    //     // === true
 
     //     cb(result);
-    // }, "getOptionValue: Checks if non-object rejected");  
+    // }, "checkCondition: ");  
 
     // assert(function (cb) {
     //     answers = {"HVfRpDskx2w7DkSGoHXj+naZUE8/sD3vOfch2uLjEXE=":{"tpsubv6rpe":{"msg":{"_uid":"tpsubv6rpe","_time":1681156327353,"_hash":"FvPNwKf6Y3bIvZq/bqR5F81NbVi/uQJLGqvKmpwIlhSmX5taTuNYFTbJNgHEHzkt"},"hash":"FvPNwKf6Y3bIvZq/bqR5F81NbVi/uQJLGqvKmpwIlhSmX5taTuNYFTbJNgHEHzkt","time":1681156327353}}, "HVfRpDskx2w7DkSGoHXj+naZUE8/sD3vOfch2uLjEXE=":{"tpsubv6rpe":{"msg":{"_uid":"tpsubv6rpe","_time":1681156327353,"_hash":"FvPNwKf6Y3bIvZq/bqR5F81NbVi/uQJLGqvKmpwIlhSmX5taTuNYFTbJNgHEHzkt"},"hash":"FvPNwKf6Y3bIvZq/bqR5F81NbVi/uQJLGqvKmpwIlhSmX5taTuNYFTbJNgHEHzkt","time":1681156327353}}}

--- a/www/assert/main.js
+++ b/www/assert/main.js
@@ -15,10 +15,10 @@ define([
     '/assert/assertions.js',
     '/common/hyperscript.js',
     '/customize/messages.js',
-
+    '../form/inner.js',
     '/bower_components/tweetnacl/nacl-fast.min.js',
     'less!/customize/src/less2/pages/page-assert.less',
-], function ($, Hyperjson, Sortify, Drive, /*Test,*/ Hash, Util, Thumb, Wire, Flat, MediaTag, Block, ApiConfig, Assertions, h, Messages) {
+], function ($, Hyperjson, Sortify, Drive, /*Test,*/ Hash, Util, Thumb, Wire, Flat, MediaTag, Block, ApiConfig, Assertions, h, Messages, Form) {
     window.Hyperjson = Hyperjson;
     window.Sortify = Sortify;
     var Nacl = window.nacl;
@@ -504,12 +504,246 @@ define([
         cb(dom.outerHTML === bodyText);
     });
 
+
+
+    ///FORMS///
+
+    assert(function (cb) {
+        var days = Form.getWeekDays();
+      
+        var result = days.length === 7; 
+      
+        cb(result);
+    }, "getWeekDays: Checks how many weekdays retrieved");  
+
+    assert(function (cb) {
+        var array = [0, 0, 1]
+        var result = Form.arrayMax(array) === 1;
+      
+        cb(result);
+    }, "arrayMax: Checks the max value of an array");  
+
+    assert(function (cb) {
+        var array = [0, 0, 0]
+        var result = Form.arrayMax(array) === 0;
+      
+        cb(result);
+    }, "arrayMax: Checks the max value of an array if all values the same");  
+
+    //TO CHECK -- NaN not a valid result type
+    // assert(function (cb) {
+    //     var array = ['example', 'text']
+    //     var result = Form.arrayMax(array) === NaN;
+      
+    //     cb(result);
+    // }, "arrayMax: Checks that NaN is returned if values are not numerical");  
+
+    assert(function (cb) {
+        var object = { uid: "1rrtjll2sl4", v: 1680688800000 }
+
+        var result = Form.getOptionValue(object) === 1680688800000
+
+        cb(result);
+    }, "getOptionValue: Checks selected option value");  
+
+    assert(function (cb) {
+        var object = { uid: "1rrtjll2sl4", v: 'example text' }
+
+        var result = Form.getOptionValue(object) === 'example text'
+
+        cb(result);
+    }, "getOptionValue: Checks selected option value (type: text)");  
+
+    assert(function (cb) {
+        var object = [{uid: "1rrtjll2sl4"}, {v: 'example text' }]
+
+        var result = Form.getOptionValue(object) === object
+
+        cb(result);
+    }, "getOptionValue: Checks if non-object rejected");  
+
+    //TO CHECK -- array not a valid result type
+    // assert(function (cb) {
+    //     var values = [{ uid: "1rrtjll2sl4", v: 1680688800000 }, { uid: "7dehmmrmac9", v: 'example text' }]
+
+    //     var result = Form.extractValues(values) === [1680688800000,'example text']
+
+    //     cb(result);
+    // }, "extractValues: Checks if option value array generated");  
+
+    // assert(function (cb) {
+    //     var values = { uid: "1rrtjll2sl4", v: 1680688800000 }
+
+    //     var result = Form.extractValues(values) === []
+
+    //     cb(result);
+    // }, "extractValues: Checks if non-array rejected");  
+
+    // assert(function (cb) {
+    //     var values = [{ uid: "1rrtjll2sl4", v: 1680688800000 }]
+
+    //     var result = Form.extractValues(values) === [1680688800000]
+
+    //     cb(result);
+    // }, "extractValues: Checks if option value array generated with only one value");  
+
+    // assert(function (cb) {
+    //     var answers = {"q+3dZT3CJ+XbkWhi5092symcW+IGJZPzd0RShYMEsHE=|35hfju0fsnu":{"msg":{"69rjecmhjb9":",mn,mn,mn,mn,mn","_uid":"35hfju0fsnu","_time":1681202916647,"_hash":"DbnusGXMDX663VM7D21tqQfz4pQIs7BKp6UpRBueoXtchIulIoqftOOWj7PpU6Lx"},"hash":"DbnusGXMDX663VM7D21tqQfz4pQIs7BKp6UpRBueoXtchIulIoqftOOWj7PpU6Lx","time":1681206767511},"SiTGBfCFwlcsLTNvufacxbc9X6mUpIoG9n1GAceMlA4=|66kj6s52omt":{"msg":{"69rjecmhjb9":"kjkjkjlkjlkjlkjlkjlkjlkjlkj","_uid":"66kj6s52omt","_time":1681205388977,"_hash":"TAoVobz7rNK3RSzkTpcaXRa47Eo63P0UvYjpGYSP1plgn8sq8iY1o4TdU4/LrnoE"},"hash":"TAoVobz7rNK3RSzkTpcaXRa47Eo63P0UvYjpGYSP1plgn8sq8iY1o4TdU4/LrnoE","time”:1681202916647},”NeDLoqFcwcKwd6rphOpEQ5X6aSlN9qGsvgi57kWKLA0=|1oq2djufaap":{"msg":{"69rjecmhjb9":"brrrrrrrrrr","_uid":"1oq2djufaap","_time":1681206767511,"_hash":"l/nJS20MK04js5WrPJCyZNF7WTmHXF9fdQXYRT0iY9DalgeetuBKnndKmwVG5kUr"},"hash":"l/nJS20MK04js5WrPJCyZNF7WTmHXF9fdQXYRT0iY9DalgeetuBKnndKmwVG5kUr","time":1681205388977}}}
+        
+    //     var result = Form.getSortedKeys(answers) === ['SiTGBfCFwlcsLTNvufacxbc9X6mUpIoG9n1GAceMlA4=|66kj6s52omt','NeDLoqFcwcKwd6rphOpEQ5X6aSlN9qGsvgi57kWKLA0=|1oq2djufaap', 'q+3dZT3CJ+XbkWhi5092symcW+IGJZPzd0RShYMEsHE=|35hfju0fsnu']
+
+    //     cb(result);
+    // }, "getSortedKeys: Checks if answer key array generated in correct order");  
+
+    //TO CHECK -- == NOT ===
+    assert(function (cb) {
+        var dateToday = new Date(1681202916647)
+
+        var result = Form.getDay(dateToday) == "Tue Apr 11 2023 00:00:00 GMT+0200 (Central European Summer Time)"
+
+        cb(result);
+    }, "getDay: Checks if correct day extracted from datetime");  
+
+    //TO CHECK -- array not a valid result type
+    // assert(function (cb) {
+    //     var dateOne = new Date('2023-01-23')
+    //     var dateTwo = new Date('2023-01-27')
+
+    //     var result = Form.getDayArray(dateOne, dateTwo) === [1674428400000,1674514800000,1674601200000,1674687600000,1674774000000]
+
+    //     cb(result);
+    // }, "getDayArray: Checks if day array generated in correct order");  
+
+    assert(function (cb) {
+        var answers = {"dnD12ORDDrY/tyN84dhBDznuJMxyPbXTk9qDygrqnmg=":{"726f3f4ulmd":{"msg":{"2":"Option 1","7mkcosm2rt0":"answer text","_uid":"726f3f4ulmd","_time":1681300220930,"_hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF"},"hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF","time":1681300220930}},"p6GuFDW8MBFm08qk8wYQtXHdKGhSBsdR5NgphX3dIyA=":{"ofu17vk29q":{"msg":{"2":"Option 2","7mkcosm2rt0":"example text","_uid":"ofu17vk29q","_time":1681300240916,"_hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ"},"hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ","time":1681300240916}},"O6+R4oi9CN2PIK/G9CcvZGWPaOnp+wdPnT4C87XLu0E=":{"7gvtagjf10j":{"msg":{"7mkcosm2rt0":"","_userdata":{"name":"example name"},"_uid":"7gvtagjf10j","_time":1681300260886,"_hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj"},"hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj","time":1681300260886}}}
+
+        var result = JSON.stringify(Form.parseAnswers(answers)) == {"dnD12ORDDrY/tyN84dhBDznuJMxyPbXTk9qDygrqnmg=|726f3f4ulmd":{"726f3f4ulmd":{"msg":{"2":"Option 1","7mkcosm2rt0":"answer text","_uid":"726f3f4ulmd","_time":1681300220930,"_hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF"},"hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF","time":1681300220930}},"p6GuFDW8MBFm08qk8wYQtXHdKGhSBsdR5NgphX3dIyA=|ofu17vk29q":{"ofu17vk29q":{"msg":{"2":"Option 2","7mkcosm2rt0":"example text","_uid":"ofu17vk29q","_time":1681300240916,"_hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ"},"hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ","time":1681300240916}},"O6+R4oi9CN2PIK/G9CcvZGWPaOnp+wdPnT4C87XLu0E=|7gvtagjf10j":{"7gvtagjf10j":{"msg":{"7mkcosm2rt0":"","_userdata":{"name":"example name"},"_uid":"7gvtagjf10j","_time":1681300260886,"_hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj"},"hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj","time":1681300260886}}}
+
+        cb(result);
+    }, "parseAnswers: Checks if answers parsed correctly");  
+
+    // //BLANK
+    // //no answers
+    // //all kinds
+
+    // assert(function (cb) {
+    //     var answers = {"dnD12ORDDrY/tyN84dhBDznuJMxyPbXTk9qDygrqnmg=":{"726f3f4ulmd":{"msg":{"2":"Option 1","7mkcosm2rt0":"answer text","_uid":"726f3f4ulmd","_time":1681300220930,"_hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF"},"hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF","time":1681300220930}},"p6GuFDW8MBFm08qk8wYQtXHdKGhSBsdR5NgphX3dIyA=":{"ofu17vk29q":{"msg":{"2":"Option 2","7mkcosm2rt0":"example text","_uid":"ofu17vk29q","_time":1681300240916,"_hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ"},"hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ","time":1681300240916}},"O6+R4oi9CN2PIK/G9CcvZGWPaOnp+wdPnT4C87XLu0E=":{"7gvtagjf10j":{"msg":{"7mkcosm2rt0":"","_userdata":{"name":"example name"},"_uid":"7gvtagjf10j","_time":1681300260886,"_hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj"},"hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj","time":1681300260886}}}
+
+    //     var result = Form.getAnswersLength(answers) === 3;
+
+    //     cb(result);
+    // }, "getOptionValue: Checks if non-object rejected");  
+
+    // assert(function (cb) {
+    //     // var answers = {"dnD12ORDDrY/tyN84dhBDznuJMxyPbXTk9qDygrqnmg=":{"726f3f4ulmd":{"msg":{"2":"Option 1","7mkcosm2rt0":"answer text","_uid":"726f3f4ulmd","_time":1681300220930,"_hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF"},"hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF","time":1681300220930}},"p6GuFDW8MBFm08qk8wYQtXHdKGhSBsdR5NgphX3dIyA=":{"ofu17vk29q":{"msg":{"2":"Option 2","7mkcosm2rt0":"example text","_uid":"ofu17vk29q","_time":1681300240916,"_hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ"},"hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ","time":1681300240916}},"O6+R4oi9CN2PIK/G9CcvZGWPaOnp+wdPnT4C87XLu0E=":{"7gvtagjf10j":{"msg":{"7mkcosm2rt0":"","_userdata":{"name":"example name"},"_uid":"7gvtagjf10j","_time":1681300260886,"_hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj"},"hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj","time":1681300260886}}}
+    //     var uid = "66gk9ne3plg"
+    //     var items = [{ uid: "66gk9ne3plg", v: "Item 1" }, { uid: "66gk9ne3plg", v: "Item 1" }]
+        
+    //     var result = Form.findItem(items, uid) === 'Item 1'
+
+    //     cb(result);
+    // }, "getOptionValue: Checks if non-object rejected");  
+
+    // assert(function (cb) {
+
+    //     var content = {"answers":{"anonymous":true,"channel":"f0c618aafe7071f8c239834793643d66","publicKey":"82gx8xzoV6bgHBQ1zoic57b2cjgxZ9zO2V67c2486ng=","validateKey":"in4+E1sKdZ+MHayQ5O2gJdMqi4Tvmk35/z/1HEqTr4M=","version":2},"form":{"1q086i8iuv0":{"opts":{"type":"text"},"type":"input"},"2de53antgns":{"opts":{"type":"text"},"type":"input"},"3nqrkethqre":{"opts":{"questions":["2de53antgns"],"when":[]},"type":"section"},"489ghit6aa6":{"opts":{"type":"text"},"type":"input"},"5l43527l18c":{"opts":{"maxLength":1000},"type":"textarea"},"5satfltfm3u":{"opts":{"type":"text"},"type":"input"}},"order":["5l43527l18c","489ghit6aa6","1q086i8iuv0","5satfltfm3u","3nqrkethqre"],"version":1}
+
+    //     var result = Form.getSections(content) === ["3nqrkethqre"]
+
+    //     cb(result);
+    // }, "getOptionValue: Checks if non-object rejected");  
+
+    // assert(function (cb) {
+    //     var content = {"answers":{"anonymous":true,"channel":"f0c618aafe7071f8c239834793643d66","publicKey":"82gx8xzoV6bgHBQ1zoic57b2cjgxZ9zO2V67c2486ng=","validateKey":"in4+E1sKdZ+MHayQ5O2gJdMqi4Tvmk35/z/1HEqTr4M=","version":2},"form":{"1q086i8iuv0":{"opts":{"type":"text"},"type":"input"},"2de53antgns":{"opts":{"type":"text"},"type":"input"},"3nqrkethqre":{"opts":{"questions":["2de53antgns"],"when":[]},"type":"section"},"489ghit6aa6":{"opts":{"type":"text"},"type":"input"},"5l43527l18c":{"opts":{"maxLength":1000},"type":"textarea"},"5satfltfm3u":{"opts":{"type":"text"},"type":"input"}},"order":["5l43527l18c","489ghit6aa6","1q086i8iuv0","5satfltfm3u","3nqrkethqre"],"version":1}
+
+    //     var result = Form.getFullOrder(content) === [ "5l43527l18c", "489ghit6aa6", "1q086i8iuv0", "5satfltfm3u", "3nqrkethqre", "2de53antgns" ]
+
+    //     cb(result);
+    // }, "getOptionValue: Checks if non-object rejected");  
+
+    // assert(function (cb) {
+    //     var answers = {"PIZkFh+x41UdYNXEEAAhzNRG2juhlH6bbvX9xw+KO0c=|2fkkqujbog4":{"msg":{"7bnj9a8okpn":{"values":{"Option 1":"1","Option 2":"0","Option 3":"0"}},"_uid":"2fkkqujbog4","_time":1681411078436,"_hash":"FbIr34E1A88dX9QXflyxwa/uLIKmucq0XYvuRQyNxfoJSN7fO4oh/KxxVekDXqAk"},"hash":"FbIr34E1A88dX9QXflyxwa/uLIKmucq0XYvuRQyNxfoJSN7fO4oh/KxxVekDXqAk","time":1681411078436}}
+        
+    //     var uid = "7bnj9a8okpn"
+
+    //     var filterCurve = false
+
+    //     var result = Form.getBlockAnswers(answers, uid, filterCurve) === [{"curve":"PIZkFh+x41UdYNXEEAAhzNRG2juhlH6bbvX9xw+KO0c=","results":{"values":{"Option 1":"1","Option 2":"0","Option 3":"0"}},"time":1681411078436}]
+
+    //     cb(result);
+    // }, "getOptionValue: Checks if non-object rejected");  
+
+    // assert(function (cb) {
+    //     var content = {"answers":{"anonymous":true,"channel":"dd879143bd4a49fd7e68f6c5109e4d9f","publicKey":"Ja4U/ESMGx/BjTTChbAZD+SFG0P+93o3F4XW6CJR0DA=","validateKey":"swNQf0LqJFWThBSE+iw8VryY2xId+QVcbn9XFeLNfXU=","version":2},"form":{"3e81recgc5g":{"opts":{"type":"text"},"type":"input"},"60tij442l02":{"opts":{"questions":["3e81recgc5g"],"when":[]},"type":"section"},"6bbmju7i65i":{"opts":{"type":"text"},"type":"input"}},"order":["6bbmju7i65i","60tij442l02"],"version":1}
+        
+    //     var result = Form.getSections(content) === [ "60tij442l02" ]
+
+    //     cb(result);
+    // }, "getOptionValue: Checks if non-object rejected");  
+
+    // assert(function (cb) {
+    //     // var answers = {"dnD12ORDDrY/tyN84dhBDznuJMxyPbXTk9qDygrqnmg=":{"726f3f4ulmd":{"msg":{"2":"Option 1","7mkcosm2rt0":"answer text","_uid":"726f3f4ulmd","_time":1681300220930,"_hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF"},"hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF","time":1681300220930}},"p6GuFDW8MBFm08qk8wYQtXHdKGhSBsdR5NgphX3dIyA=":{"ofu17vk29q":{"msg":{"2":"Option 2","7mkcosm2rt0":"example text","_uid":"ofu17vk29q","_time":1681300240916,"_hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ"},"hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ","time":1681300240916}},"O6+R4oi9CN2PIK/G9CcvZGWPaOnp+wdPnT4C87XLu0E=":{"7gvtagjf10j":{"msg":{"7mkcosm2rt0":"","_userdata":{"name":"example name"},"_uid":"7gvtagjf10j","_time":1681300260886,"_hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj"},"hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj","time":1681300260886}}}
+    //     var APP;
+    //     APP.formBlocks = [{"tag":{"jQuery360028827848464003571":{"events":{"keypress":[{"type":"keypress","origType":"keypress","guid":55,"namespace":""}],"change":[{"type":"change","origType":"change","guid":55,"namespace":""}]}}},"uid":"298095t8h92"},{"tag":{"jQuery360028827848464003571":{"events":{"keypress":[{"type":"keypress","origType":"keypress","guid":56,"namespace":""}],"change":[{"type":"change","origType":"change","guid":56,"namespace":""}]}}},"uid":"69rjecmhjb9"}]
+    //     var result = Form.getFormResults() === { "298095t8h92": "answer1", "69rjecmhjb9": "answer2" }
+
+    //     cb(result);
+    // }, "getOptionValue: Checks if non-object rejected");  
+
+    // assert(function (cb) {
+    //     var content = {"answers":{"anonymous":true,"channel":"dd879143bd4a49fd7e68f6c5109e4d9f","publicKey":"Ja4U/ESMGx/BjTTChbAZD+SFG0P+93o3F4XW6CJR0DA=","validateKey":"swNQf0LqJFWThBSE+iw8VryY2xId+QVcbn9XFeLNfXU=","version":2},"form":{"3e81recgc5g":{"opts":{"type":"text"},"type":"input"},"60tij442l02":{"opts":{"questions":["3e81recgc5g"],"when":[]},"type":"section"},"6bbmju7i65i":{"opts":{"type":"text"},"type":"input"}},"order":["6bbmju7i65i","60tij442l02"],"version":1}
+        
+    //     var uid = "6bbmju7i65i"
+
+    //     var result = Form.getSectionFromQ(content, uid) === {"arr":["76nff13m2m2","6bbmju7i65i","60tij442l02"],"idx":0}
+
+    //     cb(result);
+    // }, "getOptionValue: Checks if non-object rejected");  
+
+    // assert(function (cb) {
+    //     var content = {"answers":{"anonymous":true,"channel":"dd879143bd4a49fd7e68f6c5109e4d9f","publicKey":"Ja4U/ESMGx/BjTTChbAZD+SFG0P+93o3F4XW6CJR0DA=","validateKey":"swNQf0LqJFWThBSE+iw8VryY2xId+QVcbn9XFeLNfXU=","version":2},"form":{"3e81recgc5g":{"opts":{"type":"text"},"type":"input"},"53g43utbomt":{"opts":{"type":"text"},"type":"input"},"60tij442l02":{"opts":{"questions":["3e81recgc5g"],"when":[]},"type":"section"},"78uh4r9n10u":{"opts":{"values":[{"uid":"384h23hpkcm","v":"Option 1"},{"uid":"3nnb01frfvl","v":"Option 2"}]},"type":"radio"},"3s5hqske4pc":{"opts":{"type":"text"},"type":"input"}},"order":["60tij442l02","78uh4r9n10u","53g43utbomt","3s5hqske4pc"],"version":1}
+        
+    //     var uid = "3s5hqske4rq"
+
+    //     var result = Form.removeQuestion(content, uid) === true
+
+    //     cb(result);
+    // }, "getOptionValue: Checks if non-object rejected");  
+
+    // assert(function (cb) {
+    //     // var answers = {"dnD12ORDDrY/tyN84dhBDznuJMxyPbXTk9qDygrqnmg=":{"726f3f4ulmd":{"msg":{"2":"Option 1","7mkcosm2rt0":"answer text","_uid":"726f3f4ulmd","_time":1681300220930,"_hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF"},"hash":"0n6I/4EK2yln5mVngTMXSYSCZSIY0CZwdLcgQqwQgyEvIWen7GrcFOfGNlY8+eIF","time":1681300220930}},"p6GuFDW8MBFm08qk8wYQtXHdKGhSBsdR5NgphX3dIyA=":{"ofu17vk29q":{"msg":{"2":"Option 2","7mkcosm2rt0":"example text","_uid":"ofu17vk29q","_time":1681300240916,"_hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ"},"hash":"Af7QrdwMPTdiGK8GmVgHxHDzMwDqqyVj0nhT/ZlIrIwTLDtdRmgAuL69EEU7VIWJ","time":1681300240916}},"O6+R4oi9CN2PIK/G9CcvZGWPaOnp+wdPnT4C87XLu0E=":{"7gvtagjf10j":{"msg":{"7mkcosm2rt0":"","_userdata":{"name":"example name"},"_uid":"7gvtagjf10j","_time":1681300260886,"_hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj"},"hash":"ViJDNNV7ZzS0u15REcRh+IUyImfN0rAzNpa2KONuZRyj3+eOTxeBppTmlYaC2uXj","time":1681300260886}}}
+
+    //     var result = Form.checkCondition() === 
+
+    //     cb(result);
+    // }, "getOptionValue: Checks if non-object rejected");  
+
+    // assert(function (cb) {
+    //     answers = {"HVfRpDskx2w7DkSGoHXj+naZUE8/sD3vOfch2uLjEXE=":{"tpsubv6rpe":{"msg":{"_uid":"tpsubv6rpe","_time":1681156327353,"_hash":"FvPNwKf6Y3bIvZq/bqR5F81NbVi/uQJLGqvKmpwIlhSmX5taTuNYFTbJNgHEHzkt"},"hash":"FvPNwKf6Y3bIvZq/bqR5F81NbVi/uQJLGqvKmpwIlhSmX5taTuNYFTbJNgHEHzkt","time":1681156327353}}, "HVfRpDskx2w7DkSGoHXj+naZUE8/sD3vOfch2uLjEXE=":{"tpsubv6rpe":{"msg":{"_uid":"tpsubv6rpe","_time":1681156327353,"_hash":"FvPNwKf6Y3bIvZq/bqR5F81NbVi/uQJLGqvKmpwIlhSmX5taTuNYFTbJNgHEHzkt"},"hash":"FvPNwKf6Y3bIvZq/bqR5F81NbVi/uQJLGqvKmpwIlhSmX5taTuNYFTbJNgHEHzkt","time":1681156327353}}}
+    //     uid = '5c3p0rook1f'
+    //     form = {}
+    //     opts = {"values":[{"uid":"4ndmfa2gl7v","v":"Option 1"},{"uid":"26pd96i9v59","v":"Option 2"}]}
+
+    //     var result = Form.renderResults().show().renderResults()
+    //     console.log(result)
+    //     console.log('jkbjbjbjb')
+    //     // var days = Form.renderResults.show.showCondorcet.calculateCondorcet()
+    //     // result = 'kj';
+        
+      
+    //     cb(result);
+    // }, "Condorcet winner");  
+
+
+    ///
+
     assert.run(function (state) {
         var errors = state.errors;
         var failed = errors.length;
-
+        answers = ''
         Messages.assert_numberOfTestsPassed = "{0} / {1} tests passed.";
-
+        // console.log(obj.output)
+        console.log(errors)
         var statusClass = failed? 'failure': 'success';
         $('body').prepend(h('div.report.' + statusClass, [
             Messages._getKey('assert_numberOfTestsPassed', [
@@ -526,6 +760,7 @@ define([
             })),
         ]));
 
+
 /*
         if (failed) {
             Test.failed();
@@ -535,3 +770,4 @@ define([
     });
 
 });
+

--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -110,6 +110,7 @@ define([
         if (!Util.isObject(obj)) { return obj; }
         return obj.v;
     };
+
     var extractValues = function (values) {
         if (!Array.isArray(values)) { return []; }
         return values.map(getOptionValue);
@@ -139,6 +140,7 @@ define([
                 h('span', Messages.form_editMaxLength),
                 lengthInput
             ]);
+            //YY
             getLengthVal = function () {
                 var val = Number($(lengthInput).val()) || 1000;
                 if (val < 1) { val = 1; }
@@ -187,14 +189,14 @@ define([
         setCursorGetter(function () {
             return {};
         });
-
+        //YY
         var getSaveRes = function () {
             return {
                 maxLength: getLengthVal ? getLengthVal() : undefined,
                 type: typeSelect ? typeSelect.getValue() : undefined
             };
         };
-
+        //YY
         evOnSave.reg(function () {
             var res = getSaveRes();
             if (!res) { return; }
@@ -234,7 +236,6 @@ define([
         if (tmp && tmp.cursor) {
             cursor = tmp.cursor;
         }
-
         // Checkbox: max options
         var maxOptions, maxInput;
         if (typeof(v.max) === "number") {
@@ -301,7 +302,6 @@ define([
                 });
             }
             if (uid) { $input.data('uid', uid); }
-
             // If the input is a date, initialize flatpickr
             if (v.type && v.type !== 'text') {
                 if (v.type === 'time') {
@@ -921,7 +921,6 @@ define([
 
         return total;
     };
-
     var multiAnswerSubHeading = function (content) {
         return h('span.cp-charts-row', h('td.cp-charts-cell.cp-grid-sub-question', {
             colspan: 3,
@@ -960,13 +959,14 @@ define([
         });
         return res;
     };
-
+    
     var getSections = function (content) {
         var uids = Object.keys(content.form).filter(function (uid) {
             return content.form[uid].type === 'section';
         });
         return uids;
     };
+    
     var getFullOrder = function (content) {
         var order = content.order.slice();
         getSections(content).forEach(function (uid) {
@@ -981,7 +981,7 @@ define([
         });
         return order;
     };
-
+    
     var getBlockAnswers = function (answers, uid, filterCurve) {
         if (!answers) { return; }
         return Object.keys(answers || {}).map(function (key) {
@@ -1177,7 +1177,7 @@ define([
                 var form = content.form;
                 var framework = APP.framework;
                 var tmp = data.tmp;
-
+                //YY
                 var getConditionsValues = function () {
                     var order = getFullOrder(content);
                     var blockIdx = order.indexOf(uid);
@@ -1631,6 +1631,7 @@ define([
     };
 
     var getSortedKeys = function (answers) {
+
         return Object.keys(answers).sort(function (uid1, uid2) {
             return (answers[uid1].time || 0) - (answers[uid2].time || 0);
         });
@@ -1683,7 +1684,6 @@ define([
                 var isEmpty = function (answer) {
                     return !answer || !answer.trim();
                 };
-
                 getSortedKeys(answers).forEach(function (author) {
                     var obj = answers[author];
                     var answer = obj.msg[uid];
@@ -1998,8 +1998,9 @@ define([
                     var counts = Object.values(count[q_uid]);
                     counts.push(max);
                     max = arrayMax(counts);
+                    // console.log('countkeys1', counts)
                 });
-
+                console.log('WOOOOO HERE')
                 results.push(getEmpty(empty));
                 count_keys.forEach(function (q_uid) {
                     var q = findItem(opts.items, q_uid);
@@ -2048,6 +2049,28 @@ define([
                 evOnChange.fire();
             }, 500));
 
+            ret = {
+                tag: tag,
+                isEmpty: function () { return !$tag.val().trim(); },
+                getValue: function () {
+                    var invalid = $tag.is(':invalid');
+                    if (invalid) { return; }
+                    return $tag.val();
+                    
+                },
+                setValue: function (val) { $tag.val(val); },
+                setEditable: function (state) {
+                    if (state) { $tag.removeAttr('disabled'); }
+                    else { $tag.attr('disabled', 'disabled'); }
+                },
+                edit: function (cb) {
+
+                    return editDateOptions(cb);
+                },
+                reset: function () { $tag.val(''); }
+            }
+            // console.log('RET')
+            // console.log(ret)
 
             return {
                 tag: tag,
@@ -2368,6 +2391,7 @@ define([
                     var counts = Object.values(count[q_uid]);
                     counts.push(max);
                     max = arrayMax(counts);
+                    // console.log('countkeys2', counts)
                 });
 
                 results.push(getEmpty(empty));
@@ -2645,7 +2669,8 @@ define([
                 // If content is defined, we'll be able to click on a row to display
                 // all the answers of this user
                 var lines = makePollTable(_answers, opts, content);
-
+                // console.log('RESULTS')
+                // console.log(lines)
                 var total = makePollTotal(_answers, opts);
                 if (total) { lines.push(h('div', total)); }
 
@@ -2682,8 +2707,12 @@ define([
     };
 
     var getDay = function (d) {
+        console.log('DATE1', d)
+        console.log('DATE2', new Date(d.getFullYear(), d.getMonth(), d.getDate()))
         return new Date(d.getFullYear(), d.getMonth(), d.getDate());
     };
+
+    getDay(new Date(1681202916647))
 
     var ONE_DAY = 1000 *  60 * 60 * 24;
 
@@ -2697,6 +2726,7 @@ define([
             A.push(next);
             next += ONE_DAY;
         }
+        
         return A;
     };
 
@@ -2710,7 +2740,9 @@ define([
         Object.keys(answers).forEach(function (curve) {
             var obj = answers[curve];
             Object.keys(obj).forEach(function (uid) {
+                console.log('DATE3', obj[uid].time)
                 var day = getDay(new Date(obj[uid].time));
+                console.log('DATE4', day)
                 Util.inc(tally, +day);
             });
         });
@@ -2719,12 +2751,11 @@ define([
 
         var max_count = arrayMax(Util.values(tally));
 
+
         var min_day = Math.min.apply(null, times);
         var max_day = arrayMax(times);
         var days = getDayArray(new Date(min_day), new Date(max_day));
-
         if (days.length < 2) { return; }
-
         return h('div.timeline-container', {
             //style: 'width: 100%; height: 200px;',
 
@@ -2747,7 +2778,7 @@ define([
             )
         );
     };
-
+    
     var parseAnswers = function (answers) {
         var _answers = {};
         Object.keys(answers || {}).forEach(function (curve) {
@@ -2758,7 +2789,7 @@ define([
         });
         return _answers;
     };
-
+    
     var getAnswersLength = function (answers) {
         return Object.values(answers || {}).reduce(function (size, obj) {
             return size + Object.keys(obj).length;
@@ -2769,6 +2800,8 @@ define([
         var $container = $('div.cp-form-creator-results').empty().css('display', '');
 
         var framework = APP.framework;
+        // console.log('HI')
+        // console.log(framework)
 
         var title = framework._.title.title || framework._.title.defaultTitle;
         var titleDiv = h('h1.cp-form-view-title', title);
@@ -2786,6 +2819,7 @@ define([
         var timeline = h('div.cp-form-creator-results-timeline');
         var $timeline = $(timeline).appendTo($container);
         $timeline.append(makeTimeline(answers));
+        console.log($timeline)
         var controls = h('div.cp-form-creator-results-controls');
         var $controls = $(controls).appendTo($container);
         var results = h('div.cp-form-creator-results-content');
@@ -2890,7 +2924,7 @@ define([
                 var showCondorcetWinner = function(answers, opts, uid, form) {
                 
                     var _answers = parseAnswers(answers);
-    
+                    
                     var optionArray = [];
                     opts.values.forEach(function (option) {
                         optionArray.push(option.v);
@@ -2926,12 +2960,62 @@ define([
                             condorcetResults.append(h('span', Messages.form_noCondorcetWinner));
                         }
 
+<<<<<<< HEAD
                         var detailedResults = Object.keys(rankedResults).sort(function(a,b) { return a - b; }).reverse().map(function(result) {
                             if (rankedResults[result].length > 1) {
                                 return rankedResults[result].join(', ') + ' : ' + result;
                             } else {
                                 return rankedResults[result] + ' : ' + result;
                             }
+=======
+                        var calculateCondorcet = function() {
+                            // console.log(JSON.stringify(answers))
+                            // console.log({"HVfRpDskx2w7DkSGoHXj+naZUE8/sD3vOfch2uLjEXE=":{"tpsubv6rpe":{"msg":{"_uid":"tpsubv6rpe","_time":1681156327353,"_hash":"FvPNwKf6Y3bIvZq/bqR5F81NbVi/uQJLGqvKmpwIlhSmX5taTuNYFTbJNgHEHzkt"},"hash":"FvPNwKf6Y3bIvZq/bqR5F81NbVi/uQJLGqvKmpwIlhSmX5taTuNYFTbJNgHEHzkt","time":1681156327353}}})
+                            // console.log(JSON.stringify(block.opts))
+                            // console.log(uid)
+                            // console.log(form)
+                            var condorcetWinner;                        
+                            var detailedResults;
+                            var condorcetResults = h('span');
+                            var rankedResults = showCondorcetWinner(answers, block.opts, uid, form)[0][0];
+    
+                            if (form[uid].condorcetmethod === 'Schulze') {
+                                condorcetWinner = rankedResults[Object.keys(rankedResults).length - 1];
+                                condorcetWinner.join(', ');
+                                condorcetWinner.forEach(function(option) {
+                                    condorcetResults.append(h('span', option));
+                                });
+    
+                                detailedResults = Object.keys(rankedResults).reverse().map(function(result) {
+                                    return rankedResults[result] + ' : ' + result;
+                                });
+                                return [condorcetResults, detailedResults];
+                            } else if (form[uid].condorcetmethod === 'Ranked Pairs') {
+                                var sortedRankDict = showCondorcetWinner(answers, block.opts, uid, form)[0][1];
+                                condorcetWinner = rankedResults[0]; 
+    
+                                detailedResults = Object.keys(sortedRankDict).map(function(result) {
+                                    return result + ' : ' + sortedRankDict[result];
+                                });
+                            }
+                            return [condorcetWinner, detailedResults];
+                        };
+                        
+                        showCondorcetWinner.calculateCondorcet = calculateCondorcet;
+    
+                        var dropdownOpts = ['Schulze', 'Ranked Pairs'];
+    
+                        var options = dropdownOpts.map(function (t) {
+                            return {
+                                tag: 'a',
+                                attributes: {
+                                    'class': 'cp-form-type-value',
+                                    'data-value': t,
+                                    'href': '#',
+                                },
+                                content: t
+                            };
+>>>>>>> 1f2230a26 (initial commit)
                         });
                         return [condorcetResults, detailedResults];
                     }};
@@ -2949,6 +3033,7 @@ define([
                             },
                             content: t
                         };
+<<<<<<< HEAD
                     });
                     var dropdownConfig = {
                         text: '', // Button initial text
@@ -2994,6 +3079,38 @@ define([
                     ]));
                     
                 }
+=======
+                        var typeSelect = UIElements.createDropdown(dropdownConfig);
+    
+                        form[uid].condorcetmethod = 'Schulze';
+                        typeSelect.setValue(form[uid].condorcetmethod);
+    
+                        var method = h('div.cp-dropdown-container', typeSelect[0]);
+    
+                        var evOnSave = Util.mkEvent();
+                        typeSelect.onChange.reg(evOnSave.fire);
+                        var $typeSelect = $(typeSelect);
+    
+                        var $selector = $typeSelect.find('a');
+                        
+                        var condorcetWinner = h('span', { id: 'cW'}, calculateCondorcet()[0]);
+                        condorcetWinnerDiv = h('div.cp-form-edit-type');
+    
+                        var detailsDiv = h('details', {id: 'dD'}, Messages.form_condorcetExtendedDisplay, h('div', calculateCondorcet()[1].join(', ')));
+    
+                        $selector.click(function () {
+                            form[uid].condorcetmethod = $(this).attr('data-value');
+                            $('#cW').replaceWith(h('span', { id: 'cW'}, calculateCondorcet()[0]));
+                            $('#dD').replaceWith(h('details', {id: 'dD'}, Messages.form_condorcetExtendedDisplay, h('div', calculateCondorcet()[1].join(', '))));
+                        });
+                                            
+                        condorcetWinnerDiv.append(h('div', Messages.form_showCondorcetMethod, method, Messages.form_showCondorcetWinner, condorcetWinner, detailsDiv, {style: {margin: '10px'}}));
+                        
+                    }
+                    }
+
+                    show.showCondorcetWinner = showCondorcetWinner;
+>>>>>>> 1f2230a26 (initial commit)
                     
 
                 var q = h('div.cp-form-block-question', block.q || Messages.form_default);
@@ -3012,7 +3129,10 @@ define([
             if (header) { $results.prepend(header); }
         };
         show(answers);
-        
+
+
+        renderResults.show = show;
+
 
         if (APP.isEditor || APP.isAuditor) { $controls.show(); }
 
@@ -3332,13 +3452,13 @@ define([
     var getFormResults = function () {
         if (!Array.isArray(APP.formBlocks)) { return; }
         var results = {};
+        
         APP.formBlocks.some(function (data) {
             if (!data.getValue) { return; }
             results[data.uid] = data.getValue();
         });
         return results;
     };
-
     var getSectionFromQ = function (content, uid) {
         var arr = content.order;
         var idx = content.order.indexOf(uid);
@@ -3356,7 +3476,6 @@ define([
                 }
             });
         }
-
         return {
             uid: sectionUid,
             arr: arr,
@@ -3364,27 +3483,38 @@ define([
         };
     };
     var removeQuestion = function (content, uid) {
+        console.log('ELETER')
+        console.log(JSON.stringify(content))
+        console.log(uid)
         delete content.form[uid];
         var idx = content.order.indexOf(uid);
+        console.log(idx)
         if (idx !== -1) {
+            console.log('hey')
             content.order.splice(idx, 1);
         } else {
+            console.log('heyeo')
             getSections(content).some(function (_uid) {
                 var block = content.form[_uid];
                 if (!block.opts || !Array.isArray(block.opts.questions)) { return; }
                 var _idx = block.opts.questions.indexOf(uid);
                 if (_idx !== -1) {
+                    console.log('HERE')
                     block.opts.questions.splice(_idx, 1);
                     return true;
                 }
             });
         }
     };
-
     var checkResults = {};
     var checkCondition = function (block) {
+        console.log('BLOCK', JSON.stringify(block))
         if (!block || block.type !== 'section') { return; }
+        console.log('c1', JSON.stringify(block.opts.when))
+        console.log('c2', JSON.stringify(block.opts))
+        console.log('c3', Array.isArray(block.opts.questions))
         if (!block.opts || !Array.isArray(block.opts.questions) || !block.opts.when) {
+            console.log('trueeee')
             return true;
         }
 
@@ -3408,6 +3538,19 @@ define([
             return results[uid];
         };
         var w = block.opts.when;
+        var resultt = !w.length || w.some(function (rules) {
+            return rules.every(function (rule) {
+                var res = findResult(rule.q);
+                // Checkbox
+                if (Array.isArray(res)) {
+                    var idx = res.indexOf(rule.v);
+                    return rule.is ? idx !== -1 : idx === -1;
+                }
+                // Radio
+                return rule.is ? res === rule.v : res !== rule.v;
+            });
+        });
+        console.log('RESULYS', JSON.stringify(resultt))
         return !w.length || w.some(function (rules) {
             return rules.every(function (rule) {
                 var res = findResult(rule.q);
@@ -3523,7 +3666,6 @@ define([
             if (!$radio.find('input[type="radio"]:checked').length) {
                 return UI.warn(Messages.error);
             }
-
             var results = getFormResults();
             if (!results) { return; }
 
@@ -3746,6 +3888,7 @@ define([
                 if (noBeforeUnload) { return; }
                 $container.find('.cp-reset-button').removeAttr('disabled');
                 var results = getFormResults();
+                console.log('RESULTS', JSON.stringify(results))
                 if (isSave) {
                     answers = Util.clone(results || {});
                     _answers = Util.clone(answers);
@@ -3766,7 +3909,6 @@ define([
             var full = !uid;
             var addControl = function (type) {
                 if (type === "section" && inSection) { return; }
-
                 var btn = h('button.btn.btn-secondary', {
                     title: full ? '' : Messages['form_type_'+type],
                     'data-type': type
@@ -4907,7 +5049,7 @@ define([
                 colorTheme
             ];
         };
-
+        //YY
         var checkIntegrity = function (getter) {
             if (!content.order || !content.form) { return; }
             var changed = false;
@@ -5471,8 +5613,33 @@ define([
 
     };
 
-    Framework.create({
-        toolbarContainer: '#cp-toolbar',
-        contentContainer: '#cp-app-form-editor',
-    }, andThen);
+    // Framework.create({
+    //     toolbarContainer: '#cp-toolbar',
+    //     contentContainer: '#cp-app-form-editor',
+    // }, andThen);
+
+    return {
+    getWeekDays: getWeekDays, 
+    arrayMax: arrayMax,
+    getOptionValue: getOptionValue,
+    extractValues: extractValues,
+    getSortedKeys: getSortedKeys,
+    getDay: getDay,
+    getDayArray: getDayArray,
+    parseAnswers: parseAnswers,
+    getAnswersLength: getAnswersLength,
+    findItem: findItem,
+    getSections: getSections,
+    getFullOrder: getFullOrder,
+    getBlockAnswers: getBlockAnswers,
+    getFormResults: getFormResults,
+    getSectionFromQ: getSectionFromQ, 
+    removeQuestion: removeQuestion,
+    checkCondition: checkCondition,
+
+
+
+
+
+  };
 });

--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -189,14 +189,12 @@ define([
         setCursorGetter(function () {
             return {};
         });
-        //YY
         var getSaveRes = function () {
             return {
                 maxLength: getLengthVal ? getLengthVal() : undefined,
                 type: typeSelect ? typeSelect.getValue() : undefined
             };
         };
-        //YY
         evOnSave.reg(function () {
             var res = getSaveRes();
             if (!res) { return; }
@@ -204,7 +202,6 @@ define([
         });
 
         var saveAndCancel = saveAndCancelOptions(cb);
-
         return [
             maxLength,
             type,
@@ -985,8 +982,11 @@ define([
     var getBlockAnswers = function (answers, uid, filterCurve) {
         if (!answers) { return; }
         return Object.keys(answers || {}).map(function (key) {
+            
             var user = key.split('|')[0];
+            
             if (filterCurve && user === filterCurve) {
+                
                 var obj = answers[key];
                 // Only hide the current response (APP.editingUid), not all our responses
                 if (APP.editingUid && Util.find(obj, ['msg', '_uid']) === APP.editingUid) {
@@ -1205,6 +1205,7 @@ define([
                     }).filter(Boolean);
                     return values;
                 };
+
                 var addCondition = h('button.btn.btn-secondary', [
                     h('i.fa.fa-plus'),
                     h('span', Messages.form_conditional_add)
@@ -1631,7 +1632,6 @@ define([
     };
 
     var getSortedKeys = function (answers) {
-
         return Object.keys(answers).sort(function (uid1, uid2) {
             return (answers[uid1].time || 0) - (answers[uid2].time || 0);
         });
@@ -1998,9 +1998,7 @@ define([
                     var counts = Object.values(count[q_uid]);
                     counts.push(max);
                     max = arrayMax(counts);
-                    // console.log('countkeys1', counts)
                 });
-                // console.log('WOOOOO HERE')
                 results.push(getEmpty(empty));
                 count_keys.forEach(function (q_uid) {
                     var q = findItem(opts.items, q_uid);
@@ -2069,8 +2067,6 @@ define([
                 },
                 reset: function () { $tag.val(''); }
             }
-            // console.log('RET')
-            // console.log(ret)
 
             return {
                 tag: tag,
@@ -2391,7 +2387,6 @@ define([
                     var counts = Object.values(count[q_uid]);
                     counts.push(max);
                     max = arrayMax(counts);
-                    // console.log('countkeys2', counts)
                 });
 
                 results.push(getEmpty(empty));
@@ -2669,8 +2664,6 @@ define([
                 // If content is defined, we'll be able to click on a row to display
                 // all the answers of this user
                 var lines = makePollTable(_answers, opts, content);
-                // console.log('RESULTS')
-                // console.log(lines)
                 var total = makePollTotal(_answers, opts);
                 if (total) { lines.push(h('div', total)); }
 
@@ -2738,9 +2731,7 @@ define([
         Object.keys(answers).forEach(function (curve) {
             var obj = answers[curve];
             Object.keys(obj).forEach(function (uid) {
-                // console.log('DATE3', obj[uid].time)
                 var day = getDay(new Date(obj[uid].time));
-                // console.log('DATE4', day)
                 Util.inc(tally, +day);
             });
         });
@@ -2785,8 +2776,6 @@ define([
                 _answers[curve + '|' + uid] = all[uid];
             });
         });
-        // console.log("ANSWERS", JSON.stringify(answers))
-        // console.log("_ANSWERS", JSON.stringify(_answers))
         return _answers;
     };
     
@@ -2800,8 +2789,6 @@ define([
         var $container = $('div.cp-form-creator-results').empty().css('display', '');
 
         var framework = APP.framework;
-        // console.log('HI')
-        // console.log(framework)
 
         var title = framework._.title.title || framework._.title.defaultTitle;
         var titleDiv = h('h1.cp-form-view-title', title);
@@ -2819,7 +2806,6 @@ define([
         var timeline = h('div.cp-form-creator-results-timeline');
         var $timeline = $(timeline).appendTo($container);
         $timeline.append(makeTimeline(answers));
-        // console.log($timeline)
         var controls = h('div.cp-form-creator-results-controls');
         var $controls = $(controls).appendTo($container);
         var results = h('div.cp-form-creator-results-content');
@@ -2960,20 +2946,7 @@ define([
                             condorcetResults.append(h('span', Messages.form_noCondorcetWinner));
                         }
 
-<<<<<<< HEAD
-                        var detailedResults = Object.keys(rankedResults).sort(function(a,b) { return a - b; }).reverse().map(function(result) {
-                            if (rankedResults[result].length > 1) {
-                                return rankedResults[result].join(', ') + ' : ' + result;
-                            } else {
-                                return rankedResults[result] + ' : ' + result;
-                            }
-=======
                         var calculateCondorcet = function() {
-                            // console.log(JSON.stringify(answers))
-                            // console.log({"HVfRpDskx2w7DkSGoHXj+naZUE8/sD3vOfch2uLjEXE=":{"tpsubv6rpe":{"msg":{"_uid":"tpsubv6rpe","_time":1681156327353,"_hash":"FvPNwKf6Y3bIvZq/bqR5F81NbVi/uQJLGqvKmpwIlhSmX5taTuNYFTbJNgHEHzkt"},"hash":"FvPNwKf6Y3bIvZq/bqR5F81NbVi/uQJLGqvKmpwIlhSmX5taTuNYFTbJNgHEHzkt","time":1681156327353}}})
-                            // console.log(JSON.stringify(block.opts))
-                            // console.log(uid)
-                            // console.log(form)
                             var condorcetWinner;                        
                             var detailedResults;
                             var condorcetResults = h('span');
@@ -3015,7 +2988,6 @@ define([
                                 },
                                 content: t
                             };
->>>>>>> 1f2230a26 (initial commit)
                         });
                         return [condorcetResults, detailedResults];
                     }};
@@ -3033,7 +3005,6 @@ define([
                             },
                             content: t
                         };
-<<<<<<< HEAD
                     });
                     var dropdownConfig = {
                         text: '', // Button initial text
@@ -3079,38 +3050,6 @@ define([
                     ]));
                     
                 }
-=======
-                        var typeSelect = UIElements.createDropdown(dropdownConfig);
-    
-                        form[uid].condorcetmethod = 'Schulze';
-                        typeSelect.setValue(form[uid].condorcetmethod);
-    
-                        var method = h('div.cp-dropdown-container', typeSelect[0]);
-    
-                        var evOnSave = Util.mkEvent();
-                        typeSelect.onChange.reg(evOnSave.fire);
-                        var $typeSelect = $(typeSelect);
-    
-                        var $selector = $typeSelect.find('a');
-                        
-                        var condorcetWinner = h('span', { id: 'cW'}, calculateCondorcet()[0]);
-                        condorcetWinnerDiv = h('div.cp-form-edit-type');
-    
-                        var detailsDiv = h('details', {id: 'dD'}, Messages.form_condorcetExtendedDisplay, h('div', calculateCondorcet()[1].join(', ')));
-    
-                        $selector.click(function () {
-                            form[uid].condorcetmethod = $(this).attr('data-value');
-                            $('#cW').replaceWith(h('span', { id: 'cW'}, calculateCondorcet()[0]));
-                            $('#dD').replaceWith(h('details', {id: 'dD'}, Messages.form_condorcetExtendedDisplay, h('div', calculateCondorcet()[1].join(', '))));
-                        });
-                                            
-                        condorcetWinnerDiv.append(h('div', Messages.form_showCondorcetMethod, method, Messages.form_showCondorcetWinner, condorcetWinner, detailsDiv, {style: {margin: '10px'}}));
-                        
-                    }
-                    }
-
-                    show.showCondorcetWinner = showCondorcetWinner;
->>>>>>> 1f2230a26 (initial commit)
                     
 
                 var q = h('div.cp-form-block-question', block.q || Messages.form_default);
@@ -3448,24 +3387,15 @@ define([
         ]));
         $container.append(getLogo());
     };
-    // console.log("APP HERE!!", APP)
-    // console.log("APP HERE - kjhdjh", typeof APP)
-    // console.log("APP HERE", JSON.stringify(APP))
-    console.log("BLOX", APP.formBlocks)
+
     var getFormResults = function () {
-        // console.log("app here", APP)
-        console.log("bLOCKS")
-        if (!Array.isArray(APP.formBlocks)) { 
-            console.log('hi!!!') 
-            return; }
+        if (!Array.isArray(APP.formBlocks)) { return; }
         var results = {};
-        
+        var seen = [];
         APP.formBlocks.some(function (data) {
-            console.log('DATA', data)
             if (!data.getValue) { return; }
             results[data.uid] = data.getValue();
         });
-        console.log("RESULTS", results)
         return results;
     };
     var getSectionFromQ = function (content, uid) {
@@ -3492,23 +3422,16 @@ define([
         };
     };
     var removeQuestion = function (content, uid) {
-        // console.log('ELETER')
-        // console.log(JSON.stringify(content))
-        // console.log(uid)
         delete content.form[uid];
         var idx = content.order.indexOf(uid);
-        // console.log(idx)
         if (idx !== -1) {
-            // console.log('hey')
             content.order.splice(idx, 1);
         } else {
-            // console.log('heyeo')
             getSections(content).some(function (_uid) {
                 var block = content.form[_uid];
                 if (!block.opts || !Array.isArray(block.opts.questions)) { return; }
                 var _idx = block.opts.questions.indexOf(uid);
                 if (_idx !== -1) {
-                    // console.log('HERE')
                     block.opts.questions.splice(_idx, 1);
                     return true;
                 }
@@ -3517,16 +3440,8 @@ define([
     };
     var checkResults = {};
     var checkCondition = function (block) {
-        console.log('BLOCK', JSON.stringify(block))
-        if (!block || block.type !== 'section') { 
-            console.log("HERE1")
-            return; }
-        // console.log('c1', JSON.stringify(block.opts.when))
-        // console.log('c2', JSON.stringify(block.opts))
-        // console.log('c3', Array.isArray(block.opts.questions))
+        if (!block || block.type !== 'section') { return; }
         if (!block.opts || !Array.isArray(block.opts.questions) || !block.opts.when) {
-            // console.log('trueeee')
-            console.log("HERE2")
             return true;
         }
 
@@ -3541,12 +3456,9 @@ define([
         var findResult = function (uid) {
             if (results.hasOwnProperty(uid)) { return results[uid]; }
             APP.formBlocks.some(function (data) {
-                if (!data.getValue) { 
-                    console.log("HERE3")
-                    return; }
+                if (!data.getValue) { return; }
                 if (data.uid === String(uid)) {
                     results[uid] = data.getValue();
-                    console.log("HERE4")
                     return true;
                 }
             });
@@ -3559,16 +3471,12 @@ define([
                 // Checkbox
                 if (Array.isArray(res)) {
                     var idx = res.indexOf(rule.v);
-                    console.log("HERE5")
                     return rule.is ? idx !== -1 : idx === -1;
                 }
                 // Radio
-                console.log("HERE6", rule.is ? res === rule.v : res !== rule.v)
                 return rule.is ? res === rule.v : res !== rule.v;
             });
         });
-        console.log("BLOX", JSON.stringify(APP.formBlocks))
-        console.log('RESULYS', JSON.stringify(resultt))
         return !w.length || w.some(function (rules) {
             return rules.every(function (rule) {
                 var res = findResult(rule.q);
@@ -3684,7 +3592,6 @@ define([
             if (!$radio.find('input[type="radio"]:checked').length) {
                 return UI.warn(Messages.error);
             }
-            console.log("H2", JSON.stringify(getFormResults()))
             var results = getFormResults();
             if (!results) { return; }
 
@@ -3896,7 +3803,7 @@ define([
             });
             return;
         }
-        // console.log("JGHGJHGHGH", APP)
+
         var evOnChange = Util.mkEvent();
         if (!APP.isEditor) {
             var _answers = Util.clone(answers || {});
@@ -3907,7 +3814,6 @@ define([
                 if (noBeforeUnload) { return; }
                 $container.find('.cp-reset-button').removeAttr('disabled');
                 var results = getFormResults();
-                console.log('HI1', JSON.stringify(results))
                 if (isSave) {
                     answers = Util.clone(results || {});
                     _answers = Util.clone(answers);
@@ -4083,10 +3989,9 @@ define([
             if (isStatic) { n--; }
 
             var editButtons, editContainer;
-            console.log("WDwdwd", data)
+            
+
             APP.formBlocks.push(data);
-            console.log("HERE", getFormResults())
-            // console.log("HIEHEIHIE", APP.formBlocks)
             var previewDiv = h('div.cp-form-preview', Messages.form_preview_button);
 
             // Required radio displayed only for types that have an "isEmpty" function
@@ -4591,7 +4496,6 @@ define([
             $container.find('.cp-reset-button').attr('disabled', 'disabled');
         }
     };
-
     var getTempFields = function () {
         if (!Array.isArray(APP.formBlocks)) { return; }
         var temp = {};
@@ -5579,8 +5483,6 @@ define([
         var _redraw = Util.notAgainForAnother(function (framework, content) {
             var answers, temp;
             if (!APP.isEditor) {
-                console.log("H3", JSON.stringify(getFormResults()))
-
                 answers = getFormResults(true);
                 if (answers) { answers._isAnon = !APP.cantAnon; }
             } else { temp = getTempFields(); }
@@ -5655,15 +5557,11 @@ define([
         getFullOrder: getFullOrder,
         getBlockAnswers: getBlockAnswers,
         removeQuestion: removeQuestion,
-        
-        getFormResults: getFormResults,
-        getSectionFromQ: getSectionFromQ, 
-        
         checkCondition: checkCondition,
 
 
-
-
+        getSectionFromQ: getSectionFromQ, 
+        editTextOptions: editTextOptions
 
   };
 });

--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -2925,6 +2925,12 @@ define([
                     });
 
                     if (Object.keys(listOfLists).length !== 0) {
+                        console.log("ANSWES", JSON.stringify(_answers))
+                        console.log("OPTS", opts)
+                        console.log("UID", uid)
+                        console.log("FORM", JSON.stringify(form))
+                        console.log("OPT ARR", optionArray)
+                        console.log("LIST OF LISTS", listOfLists)
                         return Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists);
                     }
                 };
@@ -2945,52 +2951,6 @@ define([
                         } else {
                             condorcetResults.append(h('span', Messages.form_noCondorcetWinner));
                         }
-
-                        var calculateCondorcet = function() {
-                            var condorcetWinner;                        
-                            var detailedResults;
-                            var condorcetResults = h('span');
-                            var rankedResults = showCondorcetWinner(answers, block.opts, uid, form)[0][0];
-    
-                            if (form[uid].condorcetmethod === 'Schulze') {
-                                condorcetWinner = rankedResults[Object.keys(rankedResults).length - 1];
-                                condorcetWinner.join(', ');
-                                condorcetWinner.forEach(function(option) {
-                                    condorcetResults.append(h('span', option));
-                                });
-    
-                                detailedResults = Object.keys(rankedResults).reverse().map(function(result) {
-                                    return rankedResults[result] + ' : ' + result;
-                                });
-                                return [condorcetResults, detailedResults];
-                            } else if (form[uid].condorcetmethod === 'Ranked Pairs') {
-                                var sortedRankDict = showCondorcetWinner(answers, block.opts, uid, form)[0][1];
-                                condorcetWinner = rankedResults[0]; 
-    
-                                detailedResults = Object.keys(sortedRankDict).map(function(result) {
-                                    return result + ' : ' + sortedRankDict[result];
-                                });
-                            }
-                            return [condorcetWinner, detailedResults];
-                        };
-                        
-                        showCondorcetWinner.calculateCondorcet = calculateCondorcet;
-    
-                        var dropdownOpts = ['Schulze', 'Ranked Pairs'];
-    
-                        var options = dropdownOpts.map(function (t) {
-                            return {
-                                tag: 'a',
-                                attributes: {
-                                    'class': 'cp-form-type-value',
-                                    'data-value': t,
-                                    'href': '#',
-                                },
-                                content: t
-                            };
-                        });
-                        return [condorcetResults, detailedResults];
-                    }};
                     
 
                     var dropdownOpts = [Messages.form_condorcetSchulze, Messages.form_condorcetRanked];
@@ -5543,6 +5503,7 @@ define([
     }, andThen);
 
     return {
+
         getWeekDays: getWeekDays, 
         arrayMax: arrayMax,
         getOptionValue: getOptionValue,
@@ -5558,10 +5519,7 @@ define([
         getBlockAnswers: getBlockAnswers,
         removeQuestion: removeQuestion,
         checkCondition: checkCondition,
-
-
         getSectionFromQ: getSectionFromQ, 
-        editTextOptions: editTextOptions
 
   };
 });

--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -5509,10 +5509,10 @@ define([
 
     };
 
-    // Framework.create({
-    //     toolbarContainer: '#cp-toolbar',
-    //     contentContainer: '#cp-app-form-editor',
-    // }, andThen);
+    Framework.create({
+        toolbarContainer: '#cp-toolbar',
+        contentContainer: '#cp-app-form-editor',
+    }, andThen);
 
     return {
 
@@ -5532,6 +5532,7 @@ define([
         removeQuestion: removeQuestion,
         checkCondition: checkCondition,
         getSectionFromQ: getSectionFromQ, 
+        
 
   };
 });

--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -2000,7 +2000,7 @@ define([
                     max = arrayMax(counts);
                     // console.log('countkeys1', counts)
                 });
-                console.log('WOOOOO HERE')
+                // console.log('WOOOOO HERE')
                 results.push(getEmpty(empty));
                 count_keys.forEach(function (q_uid) {
                     var q = findItem(opts.items, q_uid);
@@ -2707,8 +2707,6 @@ define([
     };
 
     var getDay = function (d) {
-        console.log('DATE1', d)
-        console.log('DATE2', new Date(d.getFullYear(), d.getMonth(), d.getDate()))
         return new Date(d.getFullYear(), d.getMonth(), d.getDate());
     };
 
@@ -2740,9 +2738,9 @@ define([
         Object.keys(answers).forEach(function (curve) {
             var obj = answers[curve];
             Object.keys(obj).forEach(function (uid) {
-                console.log('DATE3', obj[uid].time)
+                // console.log('DATE3', obj[uid].time)
                 var day = getDay(new Date(obj[uid].time));
-                console.log('DATE4', day)
+                // console.log('DATE4', day)
                 Util.inc(tally, +day);
             });
         });
@@ -2787,6 +2785,8 @@ define([
                 _answers[curve + '|' + uid] = all[uid];
             });
         });
+        // console.log("ANSWERS", JSON.stringify(answers))
+        // console.log("_ANSWERS", JSON.stringify(_answers))
         return _answers;
     };
     
@@ -2819,7 +2819,7 @@ define([
         var timeline = h('div.cp-form-creator-results-timeline');
         var $timeline = $(timeline).appendTo($container);
         $timeline.append(makeTimeline(answers));
-        console.log($timeline)
+        // console.log($timeline)
         var controls = h('div.cp-form-creator-results-controls');
         var $controls = $(controls).appendTo($container);
         var results = h('div.cp-form-creator-results-content');
@@ -3448,15 +3448,24 @@ define([
         ]));
         $container.append(getLogo());
     };
-
+    // console.log("APP HERE!!", APP)
+    // console.log("APP HERE - kjhdjh", typeof APP)
+    // console.log("APP HERE", JSON.stringify(APP))
+    console.log("BLOX", APP.formBlocks)
     var getFormResults = function () {
-        if (!Array.isArray(APP.formBlocks)) { return; }
+        // console.log("app here", APP)
+        console.log("bLOCKS")
+        if (!Array.isArray(APP.formBlocks)) { 
+            console.log('hi!!!') 
+            return; }
         var results = {};
         
         APP.formBlocks.some(function (data) {
+            console.log('DATA', data)
             if (!data.getValue) { return; }
             results[data.uid] = data.getValue();
         });
+        console.log("RESULTS", results)
         return results;
     };
     var getSectionFromQ = function (content, uid) {
@@ -3483,23 +3492,23 @@ define([
         };
     };
     var removeQuestion = function (content, uid) {
-        console.log('ELETER')
-        console.log(JSON.stringify(content))
-        console.log(uid)
+        // console.log('ELETER')
+        // console.log(JSON.stringify(content))
+        // console.log(uid)
         delete content.form[uid];
         var idx = content.order.indexOf(uid);
-        console.log(idx)
+        // console.log(idx)
         if (idx !== -1) {
-            console.log('hey')
+            // console.log('hey')
             content.order.splice(idx, 1);
         } else {
-            console.log('heyeo')
+            // console.log('heyeo')
             getSections(content).some(function (_uid) {
                 var block = content.form[_uid];
                 if (!block.opts || !Array.isArray(block.opts.questions)) { return; }
                 var _idx = block.opts.questions.indexOf(uid);
                 if (_idx !== -1) {
-                    console.log('HERE')
+                    // console.log('HERE')
                     block.opts.questions.splice(_idx, 1);
                     return true;
                 }
@@ -3509,12 +3518,15 @@ define([
     var checkResults = {};
     var checkCondition = function (block) {
         console.log('BLOCK', JSON.stringify(block))
-        if (!block || block.type !== 'section') { return; }
-        console.log('c1', JSON.stringify(block.opts.when))
-        console.log('c2', JSON.stringify(block.opts))
-        console.log('c3', Array.isArray(block.opts.questions))
+        if (!block || block.type !== 'section') { 
+            console.log("HERE1")
+            return; }
+        // console.log('c1', JSON.stringify(block.opts.when))
+        // console.log('c2', JSON.stringify(block.opts))
+        // console.log('c3', Array.isArray(block.opts.questions))
         if (!block.opts || !Array.isArray(block.opts.questions) || !block.opts.when) {
-            console.log('trueeee')
+            // console.log('trueeee')
+            console.log("HERE2")
             return true;
         }
 
@@ -3529,9 +3541,12 @@ define([
         var findResult = function (uid) {
             if (results.hasOwnProperty(uid)) { return results[uid]; }
             APP.formBlocks.some(function (data) {
-                if (!data.getValue) { return; }
+                if (!data.getValue) { 
+                    console.log("HERE3")
+                    return; }
                 if (data.uid === String(uid)) {
                     results[uid] = data.getValue();
+                    console.log("HERE4")
                     return true;
                 }
             });
@@ -3544,12 +3559,15 @@ define([
                 // Checkbox
                 if (Array.isArray(res)) {
                     var idx = res.indexOf(rule.v);
+                    console.log("HERE5")
                     return rule.is ? idx !== -1 : idx === -1;
                 }
                 // Radio
+                console.log("HERE6", rule.is ? res === rule.v : res !== rule.v)
                 return rule.is ? res === rule.v : res !== rule.v;
             });
         });
+        console.log("BLOX", JSON.stringify(APP.formBlocks))
         console.log('RESULYS', JSON.stringify(resultt))
         return !w.length || w.some(function (rules) {
             return rules.every(function (rule) {
@@ -3666,6 +3684,7 @@ define([
             if (!$radio.find('input[type="radio"]:checked').length) {
                 return UI.warn(Messages.error);
             }
+            console.log("H2", JSON.stringify(getFormResults()))
             var results = getFormResults();
             if (!results) { return; }
 
@@ -3877,7 +3896,7 @@ define([
             });
             return;
         }
-
+        // console.log("JGHGJHGHGH", APP)
         var evOnChange = Util.mkEvent();
         if (!APP.isEditor) {
             var _answers = Util.clone(answers || {});
@@ -3888,7 +3907,7 @@ define([
                 if (noBeforeUnload) { return; }
                 $container.find('.cp-reset-button').removeAttr('disabled');
                 var results = getFormResults();
-                console.log('RESULTS', JSON.stringify(results))
+                console.log('HI1', JSON.stringify(results))
                 if (isSave) {
                     answers = Util.clone(results || {});
                     _answers = Util.clone(answers);
@@ -4064,9 +4083,10 @@ define([
             if (isStatic) { n--; }
 
             var editButtons, editContainer;
-
+            console.log("WDwdwd", data)
             APP.formBlocks.push(data);
-
+            console.log("HERE", getFormResults())
+            // console.log("HIEHEIHIE", APP.formBlocks)
             var previewDiv = h('div.cp-form-preview', Messages.form_preview_button);
 
             // Required radio displayed only for types that have an "isEmpty" function
@@ -5559,6 +5579,8 @@ define([
         var _redraw = Util.notAgainForAnother(function (framework, content) {
             var answers, temp;
             if (!APP.isEditor) {
+                console.log("H3", JSON.stringify(getFormResults()))
+
                 answers = getFormResults(true);
                 if (answers) { answers._isAnon = !APP.cantAnon; }
             } else { temp = getTempFields(); }
@@ -5613,29 +5635,31 @@ define([
 
     };
 
-    // Framework.create({
-    //     toolbarContainer: '#cp-toolbar',
-    //     contentContainer: '#cp-app-form-editor',
-    // }, andThen);
+    Framework.create({
+        toolbarContainer: '#cp-toolbar',
+        contentContainer: '#cp-app-form-editor',
+    }, andThen);
 
     return {
-    getWeekDays: getWeekDays, 
-    arrayMax: arrayMax,
-    getOptionValue: getOptionValue,
-    extractValues: extractValues,
-    getSortedKeys: getSortedKeys,
-    getDay: getDay,
-    getDayArray: getDayArray,
-    parseAnswers: parseAnswers,
-    getAnswersLength: getAnswersLength,
-    findItem: findItem,
-    getSections: getSections,
-    getFullOrder: getFullOrder,
-    getBlockAnswers: getBlockAnswers,
-    getFormResults: getFormResults,
-    getSectionFromQ: getSectionFromQ, 
-    removeQuestion: removeQuestion,
-    checkCondition: checkCondition,
+        getWeekDays: getWeekDays, 
+        arrayMax: arrayMax,
+        getOptionValue: getOptionValue,
+        extractValues: extractValues,
+        getSortedKeys: getSortedKeys,
+        getDay: getDay,
+        getDayArray: getDayArray,
+        parseAnswers: parseAnswers,
+        getAnswersLength: getAnswersLength,
+        findItem: findItem,
+        getSections: getSections,
+        getFullOrder: getFullOrder,
+        getBlockAnswers: getBlockAnswers,
+        removeQuestion: removeQuestion,
+        
+        getFormResults: getFormResults,
+        getSectionFromQ: getSectionFromQ, 
+        
+        checkCondition: checkCondition,
 
 
 

--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -2926,11 +2926,12 @@ define([
 
                     if (Object.keys(listOfLists).length !== 0) {
                         console.log("ANSWES", JSON.stringify(_answers))
-                        console.log("OPTS", opts)
+                        console.log("OPTS", JSON.stringify(opts))
                         console.log("UID", uid)
                         console.log("FORM", JSON.stringify(form))
-                        console.log("OPT ARR", optionArray)
-                        console.log("LIST OF LISTS", listOfLists)
+                        console.log("OPT ARR", JSON.stringify(optionArray))
+                        console.log("LIST OF LISTS", JSON.stringify(listOfLists))
+                        console.log(JSON.stringify(Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists)))
                         return Condorcet.showCondorcetWinner(_answers, opts, uid, form, optionArray, listOfLists);
                     }
                 };
@@ -2951,6 +2952,17 @@ define([
                         } else {
                             condorcetResults.append(h('span', Messages.form_noCondorcetWinner));
                         }
+
+                        var detailedResults = Object.keys(rankedResults).sort(function(a,b) { return a - b; }).reverse().map(function(result) {
+                            if (rankedResults[result].length > 1) {
+                                return rankedResults[result].join(', ') + ' : ' + result;
+                            } else {
+                                return rankedResults[result] + ' : ' + result;
+                            }
+                        });
+                        return [condorcetResults, detailedResults];
+                    }};
+
                     
 
                     var dropdownOpts = [Messages.form_condorcetSchulze, Messages.form_condorcetRanked];
@@ -5497,10 +5509,10 @@ define([
 
     };
 
-    Framework.create({
-        toolbarContainer: '#cp-toolbar',
-        contentContainer: '#cp-app-form-editor',
-    }, andThen);
+    // Framework.create({
+    //     toolbarContainer: '#cp-toolbar',
+    //     contentContainer: '#cp-app-form-editor',
+    // }, andThen);
 
     return {
 


### PR DESCRIPTION
Added a number of unit tests, testing the functionality of the Forms app, to assert.js. Note: for /assert to load and run, the Framework.create block at the end of the form/inner.js file must be commented out.