### PR TITLE
make buttons visible in mobile version of presentation mode in slides

### DIFF
--- a/www/slide/slide.js
+++ b/www/slide/slide.js
@@ -205,14 +205,23 @@ define([
     var addEvent = function () {
         console.log($modal);
         var icon_to;
-        $modal.mousemove(function () {
+        var mousemove = function () {
+            console.log($modal);
             var $buttons = $modal.find('.cp-app-slide-modal-button');
             $buttons.show();
+            
             if (icon_to) { window.clearTimeout(icon_to); }
             icon_to = window.setTimeout(function() {
                 $buttons.fadeOut();
             }, 1000);
-        });
+        }
+        
+        $modal.mousemove(mousemove);
+        $modal.on('touchstart', mousemove);
+        $modal.on('touchend', mousemove);
+        $modal.on('touchcancel', mousemove);
+        $modal.on('touchmove', mousemove);
+
         $modal.find('#cp-app-slide-modal-exit').click(function () {
             var ev = $.Event("keyup");
             ev.which = 27;


### PR DESCRIPTION
Fixes #1105

Slides hides the buttons needed for navigation and exiting in presentation mode. This makes sense because when doing a presentation, a user would prefer to not have button icons all over their presentation content. When a user hovers on the presentation, the needed buttons become visible again.

This commit makes mobile touch act similarily to hovering over the presentation.

Note: I tested this on Firefox responsive mode and iOS Chrome.