### PR TITLE
Remove custom security button as GitHub added own

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,6 +9,3 @@ contact_links:
   - name: CryptPad.fr flagship instance issue
     url: https://cryptpad.fr/support/#new
     about: Issue with an account or document on cryptpad.fr only
-  - name: Report a security vulnerability
-    url: https://ouvaton.link/pOgHev
-    about: Please give us appropriate time to verify, respond and fix before disclosure


### PR DESCRIPTION
Apparently GitHub now adds a security policy button by default (this is new, is not it?)? Also they have a policy report form behind that button. So reports can apparently now be made online at GitHub? (IMHO that is fine, just need to be aware of that)

As such, IMHO two buttons would be confusing, so let's remove our custom one here?7

Fixes https://github.com/cryptpad/cryptpad/issues/1220