### PR TITLE
Basic configuration for Apache httpd

### DIFF
--- a/docs/example.httpd.conf
+++ b/docs/example.httpd.conf
@@ -12,7 +12,7 @@ SSLProxyCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:EC
 SSLHonorCipherOrder off
 SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
 SSLProxyProtocol all -SSLv3 -TLSv1 -TLSv1.1
-SSLSessionCache "shmcb:/usr/local/apache/logs/ssl_scache(512000)"
+SSLSessionCache "shmcb:logs/ssl_scache(512000)"
 SSLSessionCacheTimeout 86400
 SSLSessionTickets off
 SSLUseStapling on


### PR DESCRIPTION
This PR is a counterpart to the [Basic example](https://github.com/cryptpad/cryptpad/blob/main/docs/example.nginx.conf) for small and midsize instances, where everything is processed by NodeJS.

This has recently been requested on the [forum](https://forum.cryptpad.org/d/96-nginx-and-apache/3). And a previous attempt to create such an example (#300) is showing its age, aimed as it was at replicating an old version of the advanced nginx example.

