### PR TITLE
#1089: Fix contextual menu `Open` on anonymous drive

### DIFF
--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -1201,7 +1201,7 @@ define([
         //        falsy (open in preview if default is not using the app)
         var defaultInApp = ['application/pdf'];
         var openFile = function (el, isRo, app) {
-            // On anonymous drive, `el` already contains file data
+            // In anonymous drives, `el` already contains file data
             var data = el.channel ? el : manager.getFileData(el);
 
             if (data.static) {

--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -1197,7 +1197,7 @@ define([
             });
         };
 
-        // `app`: true (force open wiht the app), false (force open in preview),
+        // `app`: true (force open with the app), false (force open in preview),
         //        falsy (open in preview if default is not using the app)
         var defaultInApp = ['application/pdf'];
         var openFile = function (el, isRo, app) {

--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -1201,7 +1201,8 @@ define([
         //        falsy (open in preview if default is not using the app)
         var defaultInApp = ['application/pdf'];
         var openFile = function (el, isRo, app) {
-            var data = manager.getFileData(el);
+            // On anonymous drive, `el` already contains file data
+            var data = el.channel ? el : manager.getFileData(el);
 
             if (data.static) {
                 if (data.href) {


### PR DESCRIPTION
- Related to https://github.com/cryptpad/cryptpad/issues/1089#issuecomment-2044954222

This PR fixes the case where clicking on Open on anonymous drive doesn’t do anything while raising a `missing data` error.

+ Fix a typo in the comments.