### PR TITLE
Update of the readme file for clarity

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,9 +56,10 @@ A correctly configured instance has safeguards to prevent collaborators from doi
 nasty things like injecting scripts into collaborative documents or uploads. The project
 is actively maintained and bugs that our safeguards don't catch tend to get fixed quickly.
 For this reason it is best to only use instances that are running the most recent version,
-which is currently on a three-week release cycle. It is difficult for a non-expert to
+which is currently on a three-month release cycle. It is difficult for a non-expert to
 determine whether an instance is otherwise configured correctly, so we are actively
-working on allowing administrators to opt in to a public directory of servers that
+working on allowing administrators to opt in to a [public directory of
+ervers](https://cryptpad.org/instances/) that
 meet our strict criteria for safety.
 
 # Translations

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ Previously, Docker images were community maintained, had their own repository an
 
 CryptPad offers a variety of collaborative tools that encrypt your data in your browser
 before it is sent to the server and your collaborators. In the event that the server is
-compromized the database holds encrypted data that is not of much value to attackers.
+compromized, the database holds encrypted data that is not of much value to attackers.
 
 The code which performs the encryption is still loaded from the host server like any
 other web page, so you still need to trust the administrator to keep their server secure
@@ -44,13 +44,13 @@ and to send you the right code. An expert can download code from the server and 
 that it isn't doing anything malicious like leaking your encryption keys, which is why
 this is considered an [active attack].
 
-The platform is designed to minimize what data is exposed to its operators. User registration
-and account access is based on a cryptographic key that is derived from your username
-and password so the server never needs to see either and you don't need to worry about
-whether they are being stored securely. It is impossible to verify whether a server's
-operators are logging your IP or other activity, so if you consider this information
-sensitive it is safest to assume it is being recorded and access your preferred instance
-via [Tor browser].
+The platform is designed to minimize what data is exposed to its operators. User
+registration and account access are based on cryptographic keys that are derived from your
+username and password. Hence, the server never needs to see either, and you don't need to
+worry about whether they are being stored securely. It is impossible to verify whether a
+server's operators are logging your IP or other activity, so if you consider this
+information sensitive it is safest to assume it is being recorded and access your
+preferred instance via [Tor browser].
 
 A correctly configured instance has safeguards to prevent collaborators from doing some
 nasty things like injecting scripts into collaborative documents or uploads. The project
@@ -62,7 +62,7 @@ working on allowing administrators to opt in to a [public directory of
 ervers](https://cryptpad.org/instances/) that
 meet our strict criteria for safety.
 
-For end-users, a [guide](https://blog.cryptpad.org/2024/03/14/Most-Secure-CryptPad-Usage/)
+For end users, a [guide](https://blog.cryptpad.org/2024/03/14/Most-Secure-CryptPad-Usage/)
 is provided in our blog to help understanding the security of CryptPad. This blog post
 also explains and show the best practices when using CryptPad and clarify what end-to-end
 encryption entails and not.

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 # CryptPad
 
-CryptPad is a collaboration suite that is end-to-end-encrypted and open-source. It is built to enable collaboration, synchronizing changes to documents in real time. Because all data is encrypted, the service and its administrators have no way of seeing the content being edited and stored.
+CryptPad is a collaboration suite that is end-to-end-encrypted and open-source. It is built to enable collaboration, synchronizing changes to documents in real time. Because all data are encrypted, in the eventuality of a breach, attackers have no way of seeing the stored content. Moreover, if the administators don’t alter the code, they and the service also cannot infer any piece of information about the users' content.
 
 ![Drive screenshot](screenshot.png "preview of the CryptDrive")
 

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,11 @@ working on allowing administrators to opt in to a [public directory of
 ervers](https://cryptpad.org/instances/) that
 meet our strict criteria for safety.
 
+For end-users, a [guide](https://blog.cryptpad.org/2024/03/14/Most-Secure-CryptPad-Usage/)
+is provided in our blog to help understanding the security of CryptPad. This blog post
+also explains and show the best practices when using CryptPad and clarify what end-to-end
+encryption entails and not.
+
 # Translations
 
 CryptPad can be translated with nothing more than a web browser via our


### PR DESCRIPTION
Hello,

This PR aims at updating the readme file. It introduces the following changes:
- Rewrite the leading paragraph to remove the statement that the servers cannot spy on you, as it didn’t explicit the limit of our threat model as per #1493;
- Add a paragraph about the [best practices blog post](https://blog.cryptpad.org/2024/03/14/Most-Secure-CryptPad-Usage/) for end users;
- Update the release cycle that have moved from 3 weeks to a [quaterly-basis](https://blog.cryptpad.org/2024/03/29/status-2024-03/) since `2024.3.0`;
- Add a link to the public instance directory that was mentioned to in the readme without references;
- Some general proofreading.