### PR TITLE
Optimize Apache httpd example config

### DIFF
--- a/docs/example.httpd.conf
+++ b/docs/example.httpd.conf
@@ -33,8 +33,14 @@ SSLStaplingCache "shmcb:logs/ssl_stapling(32768)"
          nokeepalive ssl-unclean-shutdown \
          downgrade-1.0 force-response-1.0
   Protocols h2 http/1.1
-  LimitRequestBody 157286400
   AddType application/javascript mjs
-  ProxyPass / http://localhost:3000/ upgrade=websocket
-  ProxyPassReverse / http://localhost:3000/
+  <Location "/">
+    LimitRequestBody 157286400
+    ProxyPass http://localhost:3000/ upgrade=websocket
+    ProxyPassReverse http://localhost:3000/
+  </Location>
+  <Location "/cryptpad_websocket">
+    ProxyPassMatch http://localhost:3003/ upgrade=websocket
+    ProxyPassReverse http://localhost:3003/
+  </Location>
 </VirtualHost>


### PR DESCRIPTION
This brings it into line with the updated default Nginx example config.