### PR TITLE
Fix ownership/sharing issues with password-protected pads

### DIFF
--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -3615,7 +3615,7 @@ define([
 
                     // Add the pad to your drive
                     // This command will also add your mailbox to the metadata log
-                    // The callback is called when the pad is stored, independantly of the metadata command
+                    // The callback is called when the pad is stored, independently of the metadata command
                     if (data.calendar) {
                         var calendarModule = common.makeUniversal('calendar');
                         var calendarData = data.calendar;

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -3559,7 +3559,7 @@ define([
         $(link).click(function (e) {
             e.preventDefault();
             e.stopPropagation();
-            var obj = { pw: msg.content.password || '' };
+            var obj = { pw: msg.content.password || '', f: 1 };
             common.openURL(Hash.getNewPadURL(msg.content.href, obj));
         });
 

--- a/www/common/cryptpad-common.js
+++ b/www/common/cryptpad-common.js
@@ -2619,7 +2619,8 @@ define([
                 disableCache: localStorage['CRYPTPAD_STORE|disableCache'],
                 driveEvents: !rdyCfg.noDrive, //rdyCfg.driveEvents // Boolean
                 lastVisit: Number(localStorage.lastVisit) || undefined,
-                blockId: blockId
+                blockId: blockId,
+                blockHash: blockHash
             };
             common.userHash = userHash || LocalStore.getUserHash();
 

--- a/www/common/notifications.js
+++ b/www/common/notifications.js
@@ -129,6 +129,7 @@ define([
             var obj = {
                 p: msg.content.isTemplate ? ['template'] : undefined,
                 t: teamNotification || undefined,
+                f: 1,
                 pw: msg.content.password || ''
             };
             common.openURL(Hash.getNewPadURL(msg.content.href, obj));

--- a/www/common/outer/mailbox-handlers.js
+++ b/www/common/outer/mailbox-handlers.js
@@ -387,8 +387,10 @@ define([
         var channel = content.channel || content.teamChannel;
 
         if (content.password) {
+            var uHash = ctx.store.data.blockHash;
+            var uSecret = Block.parseBlockHash(uHash);
+            var key = uSecret.keys.symmetric;
             content.pw = content.password;
-            var key = ctx.store.driveSecret.keys.cryptKey;
             content.password = Crypto.encrypt(content.password, key);
         }
 

--- a/www/common/outer/mailbox-handlers.js
+++ b/www/common/outer/mailbox-handlers.js
@@ -266,9 +266,9 @@ define([
         }
 
         if (content.password) {
-            var uHash = ctx.store.data.blockHash;
-            var uSecret = Block.parseBlockHash(uHash);
-            var key = uSecret.keys.symmetric;
+            let uHash = ctx.store.data.blockHash;
+            let uSecret = Block.parseBlockHash(uHash);
+            let key = uSecret.keys.symmetric;
             content.password = Crypto.encrypt(content.password, key);
         }
 
@@ -387,9 +387,9 @@ define([
         var channel = content.channel || content.teamChannel;
 
         if (content.password) {
-            var uHash = ctx.store.data.blockHash;
-            var uSecret = Block.parseBlockHash(uHash);
-            var key = uSecret.keys.symmetric;
+            let uHash = ctx.store.data.blockHash;
+            let uSecret = Block.parseBlockHash(uHash);
+            let key = uSecret.keys.symmetric;
             content.pw = content.password;
             content.password = Crypto.encrypt(content.password, key);
         }

--- a/www/common/outer/mailbox-handlers.js
+++ b/www/common/outer/mailbox-handlers.js
@@ -238,6 +238,14 @@ define([
         cb(true);
     };
 
+    // Encrypt the password under the right key before sending it via URL hash
+    var encryptPassword = function(ctx, password) {
+        let uHash = ctx.store.data.blockHash;
+        let uSecret = Block.parseBlockHash(uHash);
+        let key = uSecret.keys.symmetric;
+        return Crypto.encrypt(password, key);
+    };
+
     // Hide duplicates when receiving a SHARE_PAD notification:
     // Keep only one notification per channel: the stronger and more recent one
     var channels = {};
@@ -266,10 +274,7 @@ define([
         }
 
         if (content.password) {
-            let uHash = ctx.store.data.blockHash;
-            let uSecret = Block.parseBlockHash(uHash);
-            let key = uSecret.keys.symmetric;
-            content.password = Crypto.encrypt(content.password, key);
+            content.password = encryptPassword(ctx, content.password);
         }
 
         // Update the data
@@ -387,11 +392,8 @@ define([
         var channel = content.channel || content.teamChannel;
 
         if (content.password) {
-            let uHash = ctx.store.data.blockHash;
-            let uSecret = Block.parseBlockHash(uHash);
-            let key = uSecret.keys.symmetric;
             content.pw = content.password;
-            content.password = Crypto.encrypt(content.password, key);
+            content.password = encryptPassword(ctx, content.password);
         }
 
         if (addOwners[channel]) { return void cb(true); }

--- a/www/common/outer/mailbox-handlers.js
+++ b/www/common/outer/mailbox-handlers.js
@@ -8,7 +8,8 @@ define([
     '/common/common-hash.js',
     '/common/common-util.js',
     '/components/chainpad-crypto/crypto.js',
-], function (ApiConfig, Messaging, Hash, Util, Crypto) {
+    '/common/outer/login-block.js',
+    ], function (ApiConfig, Messaging, Hash, Util, Crypto, Block) {
 
     // Random timeout between 10 and 30 times your sync time (lag + chainpad sync)
     var getRandomTimeout = function (ctx) {
@@ -265,7 +266,9 @@ define([
         }
 
         if (content.password) {
-            var key = ctx.store.driveSecret.keys.cryptKey;
+            var uHash = ctx.store.data.blockHash;
+            var uSecret = Block.parseBlockHash(uHash);
+            var key = uSecret.keys.symmetric;
             content.password = Crypto.encrypt(content.password, key);
         }
 

--- a/www/common/outer/mailbox-handlers.js
+++ b/www/common/outer/mailbox-handlers.js
@@ -384,6 +384,7 @@ define([
         var channel = content.channel || content.teamChannel;
 
         if (content.password) {
+            content.pw = content.password;
             var key = ctx.store.driveSecret.keys.cryptKey;
             content.password = Crypto.encrypt(content.password, key);
         }

--- a/www/common/sframe-common-outer.js
+++ b/www/common/sframe-common-outer.js
@@ -1083,7 +1083,7 @@ define([
                         Cryptpad.addSharedFolder(null, secret, cb);
                     } else {
                         var _data = {
-                            password: data.password,
+                            password: data.pw || data.password,
                             href: data.href,
                             channel: data.channel,
                             title: data.title,

--- a/www/common/sframe-common-outer.js
+++ b/www/common/sframe-common-outer.js
@@ -1359,7 +1359,7 @@ define([
                                 var viewH = Utils.Hash.getViewHashFromKeys(_secret);
                                 var href = Utils.Hash.hashToHref(editH, parsed.type);
                                 var roHref = Utils.Hash.hashToHref(viewH, parsed.type);
-                                Cryptpad.setPadAttribute('password', password, w(), parsed.getUrl());
+                                Cryptpad.setPadAttribute('password', pw, w(), parsed.getUrl());
                                 Cryptpad.setPadAttribute('channel', chan, w(), parsed.getUrl());
                                 Cryptpad.setPadAttribute('href', href, w(), parsed.getUrl());
                                 Cryptpad.setPadAttribute('roHref', roHref, w(), parsed.getUrl());


### PR DESCRIPTION
This PR fixes the following issues:
- [x] #1270 
- [x] #1521
- [x] #1522 

Moreover it also fixes an UI error when the preview link when sharing the ownership of a document via CryptPad is broken.

Extra change: make the `block hash` accessible to sharedWorkers.