### PR TITLE
Fix export bug on calendars with recurring event with expiry date

### DIFF
--- a/www/calendar/export.js
+++ b/www/calendar/export.js
@@ -97,6 +97,10 @@ define([
                         });
                         return;
                     }
+                    if (k === "until") {
+                        rrule += ";"+k.toUpperCase()+"="+getICSDate(r[k]);
+                        return;
+                    }
                     rrule += ";"+k.toUpperCase()+"="+r[k];
                 });
                 return rrule;


### PR DESCRIPTION
This PR fixes a formatting issue when exporting a calendar with a recurring event that ends.

Before this PR, the end date of recurring event was formatted as timestamp (as stored intenally in CryptPad) and made `.ics` export bogus in this specific case.