### PR TITLE
add a checkup page test for /upload-blob

### DIFF
--- a/www/checkup/main.js
+++ b/www/checkup/main.js
@@ -1649,6 +1649,27 @@ define([
         });
     });
 
+    // confirm that POST requests to the `/upload-blob` endpoint
+    // return something other than a 404, which would probably indicate
+    // a reverse proxy misconfiguration
+    assert(function (cb, msg) {
+        msg.appendChild(h('span', [
+            `The server returned a 404 error when attempting to reach the `,
+            h('code', `/upload-blob`),
+            ` endpoint. This can be caused by an incorrectly configured reverse proxy.`,
+        ]));
+
+        fetch('/upload-blob', {
+            method: 'POST',
+        }).then(res => {
+            console.log({ upload_fetch_response: res });
+            cb(res.status !== 404);
+        }).catch(err => {
+            console.error(err);
+            cb(false);
+        });
+    });
+
     var row = function (cells) {
         return h('tr', cells.map(function (cell) {
             return h('td', cell);


### PR DESCRIPTION
Hi!

Some time after updating my instance to [2025.6.0](https://github.com/cryptpad/cryptpad/releases/tag/2025.6.0) I noticed that uploads stopped working.

I wrote this test to help debug the issue, and eventually realized that my NGINX config was trying (and failing) to serve `/upload-blob` as a static asset rather than proxying to the (new-ish) endpoint on the back end.

Anyone using the simplified NGINX config is unlikely to experience this issue, but it might be useful for validating more advanced configurations.