### PR TITLE
Deletion of conditional section sub-questions

### DIFF
--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -3448,6 +3448,11 @@ define([
         };
     };
     var removeQuestion = function (content, uid) {
+        if (content.form[uid].type === 'section') {
+            content.form[uid].opts.questions.forEach(function(subQuestionUid) {
+                delete content.form[subQuestionUid];
+            })
+        }
         delete content.form[uid];
         var idx = content.order.indexOf(uid);
         if (idx !== -1) {


### PR DESCRIPTION
- when deleting a conditional section from the form editor, all sub-questions are now also permanently deleted (fixes #1945 )