### PR TITLE
Hardcoded values in PDF export metadata

### DIFF
--- a/www/common/onlyoffice/inner.js
+++ b/www/common/onlyoffice/inner.js
@@ -363,7 +363,7 @@ define([
                     props.creator = "";
                 }
                 getEditor().asc_setCoreProps(props);
-            } catch () {}
+            } catch {}
         };
         var getContent = function (title) {
             try {


### PR DESCRIPTION
- Metadata of Presentation exports (PDF format) no longer show incorrect hardcoded values for 'Author'/'Title' ('Author' removed, 'Title' is now title of Presentation document) (fixes #1981)