### PR TITLE
Fix text-tools button visibility for Kanban card title editing

### DIFF
--- a/www/kanban/inner.js
+++ b/www/kanban/inner.js
@@ -482,7 +482,7 @@ define([
                 });
                 dataObject = kanban.getBoardJSON(id);
                 $(content)
-                    .find('#cp-kanban-edit-body, #cp-kanban-edit-tags, [for="cp-kanban-edit-body"], [for="cp-kanban-edit-tags"]')
+                    .find('#cp-kanban-edit-body, #cp-kanban-edit-tags, .cp-markdown-label-row, [for="cp-kanban-edit-body"], [for="cp-kanban-edit-tags"]')
                     .hide();
             } else {
                 onCursorUpdate.fire({
@@ -490,7 +490,7 @@ define([
                 });
                 dataObject = kanban.getItemJSON(id);
                 $(content)
-                    .find('#cp-kanban-edit-body, #cp-kanban-edit-tags, [for="cp-kanban-edit-body"], [for="cp-kanban-edit-tags"]')
+                    .find('#cp-kanban-edit-body, #cp-kanban-edit-tags, .cp-markdown-label-row, [for="cp-kanban-edit-body"], [for="cp-kanban-edit-tags"]')
                     .show();
             }
             // Also reset the buttons


### PR DESCRIPTION
This PR fixes the unintended display of the markdown text-tools button when editing a Kanban card title. The button should only appear when editing the card body, ensuring markdown responsiveness on mobile devices.

<img width="690" height="469" alt="image" src="https://github.com/user-attachments/assets/08ce36db-9fe9-4db9-a2ed-ee6696e17558" />
