### PR TITLE
set OTP submission button to disabled while submission is in pending

### DIFF
--- a/www/common/common-interface.js
+++ b/www/common/common-interface.js
@@ -1662,6 +1662,7 @@ define([
         var $input = $(input);
         var $btn = $(btn).click(function () {
             var val = $input.val();
+            $btn.prop('disabled', true);
             if (!val) { return void UI.getOTPScreen(cb, exitable, 'INVALID_CODE'); }
             cb(val);
         });


### PR DESCRIPTION
I've been meaning to do something about this rough edge for a while, but finally got around to it today.

Basically, when you submit an OTP for a 2FA-protected account via the login page by hitting "Enter", there is nothing to indicate whether that keypress has had any effect.

This PR sets the "disabled" attribute on the submission button when it is clicked, which happens indirectly when the user presses the Enter key.

I only did some very rudimentary testing of this change, but it seemed to work as intended for at least the basic use-cases I could think of.