### PR TITLE
Enable Dawio Sketch UI 

### DIFF
--- a/src/common/common-util.js
+++ b/src/common/common-util.js
@@ -314,13 +314,7 @@ const factory = (NaclUtil) => {
     };
 
     Util.deduplicateString = function (array) {
-        var a = array.slice();
-        for(var i=0; i<a.length; i++) {
-            for(var j=i+1; j<a.length; j++) {
-                if(a[i] === a[j]) { a.splice(j--, 1); }
-            }
-        }
-        return a;
+        return Array.from(new Set(array));
     };
 
     /*


### PR DESCRIPTION
<img width="1946" height="1660" alt="image" src="https://github.com/user-attachments/assets/622705e5-f75c-476e-9145-123f0c09cd4c" />

The [Sketch theme](https://www.drawio.com/blog/diagram-editor-theme) of Drawio presents a much friendlier interface by default and encourages freehand drawing as much as shapes. This PR enables this mode by default and explores other aspects of drawio config that we could take advantage of. 