### PR TITLE
Enable Drawio Sketch theme

### DIFF
--- a/www/diagram/inner.js
+++ b/www/diagram/inner.js
@@ -186,6 +186,7 @@ define([
                 saveAndExit: 0,
                 noExitBtn: 1,
                 browser: 0,
+                ui: 'sketch',
 
                 noDevice: 1,
                 filesupport: 0,


### PR DESCRIPTION
<img width="1946" height="1660" alt="Screenshot from 2025-10-28 16-36-49" src="https://github.com/user-attachments/assets/3d3eca77-f48e-42fe-943c-267bd0109a9e" />


The [Sketch theme](https://www.drawio.com/blog/diagram-editor-theme) of Drawio presents a much friendlier interface by default and encourages freehand drawing as much as shapes. This PR enables this mode by default and explores other aspects of drawio config that we could take advantage of. 

Further things to explore:

- [ ] Other flags in the [available parameters](https://www.drawio.com/doc/faq/supported-url-parameters) that could improve our integration
- [ ] UI adjustments e.g. empty alert container at top right
- [ ] Providing our own UI switch to reload diagrams in Simple or Sketch UI? 