### PR TITLE
Disable dragging when selecting text inside title and items for Kanban cards

### DIFF
--- a/www/kanban/inner.js
+++ b/www/kanban/inner.js
@@ -1057,6 +1057,11 @@ define([
             kanban.options.dragItems = false;
             e.stopPropagation();
         });
+        $(document).on('mouseup', function (e) {
+            var drag = kanban.drag;
+            kanban.options.dragItems = drag;
+            e.stopPropagation();
+        });
 
         framework._.cpNfInner.metadataMgr.onChange(function () {
             var md = framework._.cpNfInner.metadataMgr.getPrivateData();


### PR DESCRIPTION
This PR aims to fix #1990 by improving the drag-and-drop behavior in Kanban cards:

- [x] Disable card dragging when selecting text inside the card title or items
- [x] Allow normal dragging behavior when clicking outside text selection areas