### PR TITLE
Fix: Profile description editor now shows saved value without requiring focus

### DIFF
--- a/www/settings/inner.js
+++ b/www/settings/inner.js
@@ -2010,9 +2010,6 @@ define([
         });
 
         cb(labelled);
-        setTimeout(() => {
-            editor.refresh();
-        }, 10);
     }, false, true);
 
 
@@ -2034,6 +2031,9 @@ define([
         cat.forEach(function(c) {
             APP.$rightside.find('.' + c).show();
         });
+        if (APP.editor) {
+            APP.editor.refresh();
+        }
     };
 
     var SIDEBAR_ICONS = {


### PR DESCRIPTION
This PR aims to fix #2099:

- [x] The editor should display the saved profile description immediately upon loading, without the user having to click inside the editor