### PR TITLE
Performance improvements (3/3) to example-advanced.nginx.conf

### DIFF
--- a/docs/example-advanced.nginx.conf
+++ b/docs/example-advanced.nginx.conf
@@ -391,6 +391,6 @@ server {
         # Set all the rules you composed above.
         add_header Content-Security-Policy "default-src 'none'; child-src $childSrc; worker-src $workerSrc; media-src $mediaSrc; style-src $styleSrc; script-src $scriptSrc; connect-src $connectSrc; font-src $fontSrc; img-src $imgSrc; frame-src $frameSrc; frame-ancestors $frameAncestors" always;
 
-        try_files /customize/www/$uri /customize/www/$uri/index.html /src/$uri /www/$uri /www/$uri/index.html /src/$uri /customize/$uri;
+        try_files /customize/www/$uri /customize/www/$uri/index.html /src/$uri /www/$uri /www/$uri/index.html /customize/$uri;
     }
 }

--- a/docs/example-advanced.nginx.conf
+++ b/docs/example-advanced.nginx.conf
@@ -8,6 +8,21 @@
 #   installation (http server by the Nodejs process). If you are using CryptPad
 #   in production and require professional support please contact sales@cryptpad.fr
 
+proxy_http_version 1.1;
+proxy_set_header   "Connection" "";
+
+upstream node_http {
+    zone node_http 64k;
+    server localhost:3000 max_fails=1 fail_timeout=2s;
+    keepalive 2;
+}
+
+upstream node_ws {
+    zone node_ws 64k;
+    server localhost:3003 max_fails=1 fail_timeout=2s;
+    keepalive 2;
+}
+
 server {
     listen 80;
     listen [::]:80;
@@ -195,7 +210,8 @@ server {
         # Websocket traffic still needs to be handled by the main process, which means it needs
         # to be hosted on a different port. By default 3003 will be used, though this is configurable
         # via config.websocketPort
-        proxy_pass http://localhost:3003;
+        proxy_pass http://node_ws;
+        proxy_next_upstream error timeout http_500;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -283,7 +299,8 @@ server {
     # the caching variable which is applied to every other resource
     # which is loaded during that session.
     location ^~ /api/ {
-        proxy_pass http://localhost:3000;
+        proxy_pass http://node_http;
+        proxy_next_upstream error timeout http_500;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -297,7 +314,8 @@ server {
     }
 
     location = /extensions.js/ {
-        proxy_pass http://localhost:3000;
+        proxy_pass http://node_http;
+        proxy_next_upstream error timeout http_500;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -321,7 +339,8 @@ server {
             add_header 'Content-Length' 0;
             return 204;
         }
-        proxy_pass http://localhost:3000;
+        proxy_pass http://node_http;
+        proxy_next_upstream error timeout http_500;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -356,7 +375,8 @@ server {
         proxy_hide_header 'Access-Control-Allow-Origin';
         proxy_hide_header 'Cross-Origin-Resource-Policy';
         proxy_hide_header 'Cross-Origin-Embedder-Policy';
-        proxy_pass http://localhost:3000;
+        proxy_pass http://node_http;
+        proxy_next_upstream error timeout http_500;
     }
 
     # The nodejs server has some built-in forwarding rules to prevent


### PR DESCRIPTION
This is the final part of the patch series for #1704. It configures one upstream group for each endpoint to allow worker processes (set to `auto`, ie the number of cores, in [most](https://exampleconfig.com/default/nginx/etc-nginx-nginx-conf?os=ubuntu2404) [nginx](https://src.fedoraproject.org/rpms/nginx/blob/rawhide/f/nginx.conf#_6) [distributions](https://exampleconfig.com/default/nginx/etc-nginx-nginx-conf?os=debian13)) to share a memory zone.

Since the [F5 example configuration](https://web.archive.org/web/20251002103745/https://www.f5.com/company/blog/nginx/avoiding-top-10-nginx-configuration-mistakes#upstream-groups) is for the use case of a single node-based backend application, I’ve simply adapted it for cryptpad.

Note that it’s [recommended](https://web.archive.org/web/20251002103745/https://www.f5.com/company/blog/nginx/avoiding-top-10-nginx-configuration-mistakes#no-keepalives) to set `keepalive` to twice the number of servers listed in the `upstream{}` block (which doesn’t limit the total number of connections to upstream servers that a worker process can open), so when testing on a large instance, there’s no need to increase this parameter.

The original article by F5, which is the company behind nginx, is here: https://www.f5.com/company/blog/nginx/avoiding-top-10-nginx-configuration-mistakes#upstream-groups.