### PR TITLE
Switch to docker alpine

### DIFF
--- a/install-onlyoffice.sh
+++ b/install-onlyoffice.sh
@@ -289,7 +289,7 @@ install_version() {
 
         curl "https://github.com/cryptpad/onlyoffice-editor/releases/download/$VERSION/onlyoffice-editor.zip" --location --output "onlyoffice-editor.zip"
         echo "$HASH onlyoffice-editor.zip" >onlyoffice-editor.zip.sha512
-        if ! sha512sum --check onlyoffice-editor.zip.sha512; then
+        if ! sha512sum -c onlyoffice-editor.zip.sha512; then
             echo "onlyoffice-editor.zip does not match expected checksum"
             exit 1
         fi
@@ -332,7 +332,7 @@ install_x2t() {
         ensure_command_available unzip
         curl "https://github.com/cryptpad/onlyoffice-x2t-wasm/releases/download/$VERSION/x2t.zip" --location --output x2t.zip
         echo "$HASH x2t.zip" >x2t.zip.sha512
-        if ! sha512sum --check x2t.zip.sha512; then
+        if ! sha512sum -c x2t.zip.sha512; then
             echo "x2t.zip does not match expected checksum"
             exit 1
         fi


### PR DESCRIPTION
Our current Docker base image `node:lts-slim` includes the [CVE-2023-45853](https://avd.aquasec.com/nvd/cve-2023-45853). To make sure not any red lamps go on I switched the base image to `node:lts-alpine`.

Docker images can be scanned for CVEs like this:
``` shell
docker run -v /var/run/docker.sock:/var/run/docker.sock -v $HOME/Library/Caches:/root/.cache/ aquasec/trivy:latest image cryptpad/cryptpad:latest

docker run -v /var/run/docker.sock:/var/run/docker.sock -v $HOME/Library/Caches:/root/.cache/ aquasec/trivy:latest image node:lts-slim

docker run -v /var/run/docker.sock:/var/run/docker.sock -v $HOME/Library/Caches:/root/.cache/ aquasec/trivy:latest image node:lts-alpine
```