### PR TITLE
CKEditor undo stack cleared on refresh 

### DIFF
--- a/www/pad/inner.js
+++ b/www/pad/inner.js
@@ -1083,6 +1083,7 @@ define([
 
         framework.onReady(function(newPad) {
             editor.focus();
+            editor.resetUndo();
 
             if (!module.isMaximized) {
                 module.isMaximized = true;


### PR DESCRIPTION
- whenever the Pad application is reloaded/refreshed, the undo stack is cleared, meaning that changes made prior to refresh cannot be erased with `CTRL`+`Z` (fixes #1387)