### PR TITLE
Fix: Context menu new document options now respect selected type

### DIFF
--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -5292,8 +5292,7 @@ define([
                 showUploadFolderModal();
             }
             else if ($this.hasClass("cp-app-drive-context-newdoc")) {
-                console.log($this.data('type'));
-                var ntype = $this.data('type') || 'code';
+                var ntype = $this.data('type') || 'pad';
                 if (ntype === 'link') {
                     return void showLinkModal();
                 }


### PR DESCRIPTION
This PR fixes #2123:

- [x] Each option now creates the corresponding document type (code, sheet, doc, presentation, etc.)