### PR TITLE
Calendar export fixes

### DIFF
--- a/www/calendar/export.js
+++ b/www/calendar/export.js
@@ -227,7 +227,7 @@ define([
 
                     if (ud.from) { // "From" updates are not supported by ICS: make a new event
                         var _new = Util.clone(prev);
-                        r.until = getICSDate(d - 1); // Stop previous recursion
+                        r.until = d - 1; // Stop previous recursion
                         delete r.count;
                         addEvent(ICS, prev, null); // Add previous event
                         Array.prototype.push.apply(ICS, toAdd); // Add individual updates


### PR DESCRIPTION
This PR contains a couple of fixes for calendar exports

- Exporting an empty calendar resulted in an error. Now it produces a no-event ICS.
- Fix #2150. The issue spanned from the fact that as modifying future events isn’t a feature of ICS, we were splitting the recurring event into several events where one of them stopped. However, this preprocessing was done twice, the second time not producing the expected value (which was not NaN). This PR skips the first pre-formatting before the pass in the ICS exporter (providing it well-formed data).