### PR TITLE
change code-pad to code

### DIFF
--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -1377,7 +1377,7 @@ define([
 
         var apps = {
             pad: 'richtext',
-            code: 'code-pad',
+            code: 'code',
             slide: 'slides',
             sheet: 'sheets',
             poll: 'poll',


### PR DESCRIPTION
Closes https://github.com/cryptpad/cryptpad/issues/2152

Description:
In www/common/common-ui-elements.js where the links are defined the string associated to the type "code" has been changed from "code-pad" to "code", so now the redirection is on the correct link.