### PR TITLE
bug fix for nested conditions blocks in form

### DIFF
--- a/www/form/inner.js
+++ b/www/form/inner.js
@@ -4718,7 +4718,17 @@ define([
                 }
                 var show = checkCondition(block);
                 block.opts.questions.forEach(function (_uid) {
-                    $container.find('.cp-form-block[data-id="'+_uid+'"]').toggle(show);
+                    var $blockEl = $container.find('.cp-form-block[data-id="'+_uid+'"]');
+                    $blockEl.toggle(show);
+                    
+                    // If section is being hidden, reset answers for questions in this section
+                    if (!show) {
+                        APP.formBlocks.forEach(function (formBlock) {
+                            if (formBlock.uid === _uid && formBlock.reset) {
+                                formBlock.reset();
+                            }
+                        });
+                    }
                 });
             });
         });


### PR DESCRIPTION
**Bug description:**
Fix of a bug when inserting nested conditions in forms. In particular, when both conditions are met, all the questions are displayed, when the first one is not met anymore, the blocks related to the second one are still displayed. The reason of the bug is that those answered are saved even if not displayed and thus the second condition was still met. 

**Description:**
I have changed the code so that the if a condition is not met, the answers are reset, so that the second condition is not displayed anymore. 
I have checked also the saving part and the results are coherent.