### PR TITLE
Update status for trashed OnlyOffice documents

### DIFF
--- a/www/common/onlyoffice/inner.js
+++ b/www/common/onlyoffice/inner.js
@@ -3380,6 +3380,7 @@ Uncaught TypeError: Cannot read property 'calculatedType' of null
             var $forgetButton = common.createButton('forget', true, {}, function (err) {
                 if (err) { return; }
                 setEditable(false);
+                toolbar.forgotten();
             });
             var $forget = UIElements.getEntryFromButton($forgetButton);
             toolbar.$drawer.append($forget);


### PR DESCRIPTION
- fixes #1263 (OnlyOffice documents moved to trash show relevant status in toolbar, instead of "Saved") 