### PR TITLE
Fix Shared Folder added to own drive instead of team drive

### DIFF
--- a/www/drive/main.js
+++ b/www/drive/main.js
@@ -26,10 +26,14 @@ define([
 
             // SF and logged in: add shared folder
             if (Utils.LocalStore.isLoggedIn()) {
-                Cryptpad.addSharedFolder(null, secret, function (id) {
+                Cryptpad.addSharedFolder(Cryptpad.initialTeam, secret, function (id) {
                     if (id && typeof(id) === "object" && id.error) {
                         sframeChan.event("EV_RESTRICTED_ERROR");
                         return;
+                    }
+
+                    if (Cryptpad.initialTeam && Cryptpad.initialTeam !== -1) {
+                        window.location.href = '/teams/';
                     }
 
                     window.CryptPad_newSharedFolder = id;


### PR DESCRIPTION
* When a viewer from a team tries to share a "shared folder" with the team, it sends a notification to the team members.
* Opening this notification was adding the shared folder to the user's own drive instead of the team drive.