### PR TITLE
Fix paragraph selection in richtext for mobile

### DIFF
--- a/customize.dist/ckeditor-config.js
+++ b/customize.dist/ckeditor-config.js
@@ -13,7 +13,7 @@ CKEDITOR.editorConfig = function( config ) {
     config.removeButtons= 'Source,Maximize';
     // magicline plugin inserts html crap into the document which is not part of the
     // document itself and causes problems when it's sent across the wire and reflected back
-    var isMobile = /Android|iPad|iPhone|iPod/i.test(navigator.userAgent);
+    var isMobile = window.matchMedia ? window.matchMedia('(pointer: coarse)').matches : navigator.maxTouchPoints > 0;
     config.removePlugins= 'resize,elementspath,liststyle' + (isMobile ? ',contextmenu,tabletools,tableselection' : '');
     config.resize_enabled= false; //bottom-bar
     config.extraPlugins= 'autolink,colorbutton,colordialog,font,indentblock,justify,mediatag,print,blockbase64,mathjax,wordcount,comments';

--- a/customize.dist/ckeditor-config.js
+++ b/customize.dist/ckeditor-config.js
@@ -13,7 +13,8 @@ CKEDITOR.editorConfig = function( config ) {
     config.removeButtons= 'Source,Maximize';
     // magicline plugin inserts html crap into the document which is not part of the
     // document itself and causes problems when it's sent across the wire and reflected back
-    config.removePlugins= 'resize,elementspath,liststyle';
+    var isMobile = /Android|iPad|iPhone|iPod/i.test(navigator.userAgent);
+    config.removePlugins= 'resize,elementspath,liststyle' + (isMobile ? ',contextmenu,tabletools,tableselection' : '');
     config.resize_enabled= false; //bottom-bar
     config.extraPlugins= 'autolink,colorbutton,colordialog,font,indentblock,justify,mediatag,print,blockbase64,mathjax,wordcount,comments';
     config.toolbarGroups= [


### PR DESCRIPTION
This PR aims to fix #2172:

- [x] Remove the ckeditor contextmenu that prevents native actions from happening 
- [x] Make user experience on mobile as smooth as possible