### PR TITLE
Fix app icons and spacing in Drive "Open in" context menu

### DIFF
--- a/customize.dist/src/less2/include/contextmenu.less
+++ b/customize.dist/src/less2/include/contextmenu.less
@@ -33,6 +33,16 @@
         li {
             padding: 0;
             font-size: @colortheme_app-font-size;
+            a.cp-app-drive-context-openincode,
+            a.cp-app-drive-context-openinsheet,
+            a.cp-app-drive-context-openindoc,
+            a.cp-app-drive-context-openinpresentation {
+                & > svg.lucide {
+                    margin: 0 0.25rem;
+                    vector-effect: non-scaling-stroke;
+                    stroke-width: 1.7;
+                }
+            }
             &.dropdown-submenu {
                 position: relative;
                 &> a {

--- a/www/common/drive-ui.js
+++ b/www/common/drive-ui.js
@@ -369,8 +369,9 @@ define([
 
         APP.premiumPlan = priv.plan;
         var getOpenIn = function (app) {
-            var icon = AppConfig.applicationsIcon[app];
-            var html = '<i data-lucide="'+icon+'"></i>' + Messages.type[app];
+            var icon = AppConfig.applicationsIcon[app] || app;
+            var iconHtml = Icons.get(icon).outerHTML;
+            var html = iconHtml + Messages.type[app];
             return Messages._getKey('fc_openIn', [html]);
         };
         var restricted = {};


### PR DESCRIPTION
This PR aims to fix #2209:

- [x] Show the correct app icon in the Drive "Open in" menu for Code, Document, Sheet, and Presentation (and other files related to Code)
- [x] Fix spacing/alignment between icon and label in the context menu
- [x] Test multiple file extensions (code - .js, .py, .jpg, .pdf)