### PR TITLE
Fix #2216: Table of contents not clickable in read-only mode

### DIFF
--- a/www/pad/inner.js
+++ b/www/pad/inner.js
@@ -728,13 +728,21 @@ define([
             var href = el.getAttribute('href');
             if (/^#/.test(href)) {
                 try {
+                    var foundAnchor = false;
                     $inner.find('.cke_anchor[data-cke-realelement]').each(function (j, el) {
+                        if (foundAnchor) { return; }
                         var i = editor.restoreRealElement($(el));
                         var node = i.$;
                         if (node.id === href.slice(1)) {
                             el.scrollIntoView();
+                            foundAnchor = true;
                         }
                     });
+                    // Fallback: try to find anchor by ID directly
+                    if (!foundAnchor) {
+                        var anchorsById = $inner.find('#' + href.slice(1));
+                        if (anchorsById.length) { anchorsById[0].scrollIntoView(); }
+                    }
                 } catch (err) {}
                 return;
             }


### PR DESCRIPTION
Fixes #2216

## Problem
In a Document with a hyperlinked table of contents, the items are only clickable in edit mode. In read-only mode, the items can be clicked, but this does not do anything.

## Root Cause
The `openLink` function in `www/pad/inner.js` uses `editor.restoreRealElement` to find anchors, which may not work properly in read-only mode. Additionally, there was no fallback to find anchors by their ID directly.

## Solution
1. Added a `foundAnchor` flag to stop searching after first match (avoid unnecessary iterations)
2. Added fallback code to find anchor by ID directly using `$inner.find('#' + href.slice(1))`

This matches the implementation already present in `www/pad/links.js` which has this fallback.

## Testing
- Tested anchor link scrolling in read-only mode
- Verified fallback works when CKEditor real element is not available