### PR TITLE
Add rate limiting to the nginx advanced configuration example

### DIFF
--- a/docs/example-advanced.nginx.conf
+++ b/docs/example-advanced.nginx.conf
@@ -23,6 +23,9 @@ server {
     return 301 https://$host$request_uri;
 }
 
+# Websocket connections rate limiting
+limit_req_zone $binary_remote_addr zone=wslimit:20m rate=30r/m;
+
 server {
     listen 443 ssl;
     listen [::]:443 ssl;
@@ -190,6 +193,10 @@ server {
     # We prefer to serve static content from nginx directly and to leave the API server to handle
     # the dynamic content that only it can manage. This is primarily an optimization
     location ^~ /cryptpad_websocket {
+        # Websocket connections rate limiting
+        limit_req zone=wslimit burst=5 nodelay;
+        limit_req_status 429;
+
         # XXX
         # static assets like blobs and blocks are served by clustered workers in the API server
         # Websocket traffic still needs to be handled by the main process, which means it needs


### PR DESCRIPTION
This PR adds rate limiting to to the example config for nginx.

It completes #2106 with the configuration from [this comment](https://github.com/cryptpad/cryptpad/pull/2106#issuecomment-3876483801).