### PR TITLE
Improve crowdfunding banner UI and show logic

### DIFF
--- a/customize.dist/messages.js
+++ b/customize.dist/messages.js
@@ -138,7 +138,7 @@ define(req, function(AppConfig, Default, Language) {
     // To be edited for the Spring Release
     // Messages.dontShowAgain = "Don't show again";
     // Messages.crowdfunding_popup_text = "<h3>We need your help!</h3>To ensure that CryptPad is actively developed, consider supporting the project via the OpenCollective page, where you can see our <b>Roadmap</b> and <b>Funding goals</b>."
-    // Messages.crowdfunding_popup_text2 = "Alternatively, we have subscription plans available on <a href='https://cryptpad.fr'>CryptPad.fr</a>."
+    Messages.crowdfunding_popup_text2 = "Alternatively, you can subscribe on this instance." // XXX
     return Messages;
 
 });

--- a/customize.dist/messages.js
+++ b/customize.dist/messages.js
@@ -134,6 +134,8 @@ define(req, function(AppConfig, Default, Language) {
         }
     };
 
+    /// XXX
+    Messages.crowdfunding_subscribe = "Subscribe";
     return Messages;
 
 });

--- a/customize.dist/messages.js
+++ b/customize.dist/messages.js
@@ -135,7 +135,10 @@ define(req, function(AppConfig, Default, Language) {
     };
 
     /// XXX
-    Messages.crowdfunding_subscribe = "Subscribe";
+    // To be edited for the Spring Release
+    // Messages.dontShowAgain = "Don't show again";
+    // Messages.crowdfunding_popup_text = "<h3>We need your help!</h3>To ensure that CryptPad is actively developed, consider supporting the project via the OpenCollective page, where you can see our <b>Roadmap</b> and <b>Funding goals</b>."
+    // Messages.crowdfunding_popup_text2 = "Alternatively, we have subscription plans available on <a href='https://cryptpad.fr'>CryptPad.fr</a>."
     return Messages;
 
 });

--- a/customize.dist/src/less2/include/alertify.less
+++ b/customize.dist/src/less2/include/alertify.less
@@ -371,6 +371,15 @@
                     vertical-align: middle;
                 }
             }
+            @media screen and (max-width: @browser_media-medium-screen) {
+                .cp-crowdfunding-modal nav {
+                    display: flex;
+                    flex-wrap: wrap;
+                    justify-content: center;
+                    align-items: center;
+                    gap: 0.5rem;
+                }
+            }
         }
     }
 

--- a/customize.dist/src/less2/include/alertify.less
+++ b/customize.dist/src/less2/include/alertify.less
@@ -376,7 +376,6 @@
                     display: flex;
                     flex-wrap: wrap;
                     justify-content: center;
-                    align-items: center;
                     gap: 0.5rem;
                 }
             }

--- a/customize.dist/src/less2/include/drive.less
+++ b/customize.dist/src/less2/include/drive.less
@@ -976,6 +976,12 @@
             stroke-width: 3.5;
             vector-effect: non-scaling-stroke;
         }
+        &.cp-app-drive-content-grid {
+            li.cp-app-drive-element-row > svg.lucide * {
+                stroke-width: 3.5;
+                vector-effect: non-scaling-stroke;
+            }
+        }
     }
 
     #cp-app-drive-new-ghost-dialog.cp-modal-container {

--- a/www/common/common-icons.js
+++ b/www/common/common-icons.js
@@ -85,7 +85,7 @@ define([
         "share": "share-2",
         "download": "hard-drive-download",
         "destroy": "shredder",
-        "donate": "hand-coins",
+        "donate": "hand-heart",
         "send": "send",
         "cloud-upload": "cloud-upload",
         "print": "printer",

--- a/www/common/common-icons.js
+++ b/www/common/common-icons.js
@@ -251,8 +251,9 @@ define([
         // Other
         "maintenance": "construction",
         "release-notes": "notepad-text",
-        "donate": "hand-heart",
-        "snooze": "timer",
+        "crowdfunding-donate": "hand-heart",
+        "crowdfunding-snooze": "timer",
+        "crowdfunding-donate2": "ticket"
     };
 
     Icons.add = (newIcons) => {

--- a/www/common/common-icons.js
+++ b/www/common/common-icons.js
@@ -251,8 +251,8 @@ define([
         // Other
         "maintenance": "construction",
         "release-notes": "notepad-text",
-        "subscribe": "heart-handshake",
         "donate": "hand-heart",
+        "snooze": "timer",
     };
 
     Icons.add = (newIcons) => {

--- a/www/common/common-icons.js
+++ b/www/common/common-icons.js
@@ -250,7 +250,9 @@ define([
         "badge-error": "circle-alert",
         // Other
         "maintenance": "construction",
-        "release-notes": "notepad-text"
+        "release-notes": "notepad-text",
+        "subscribe": "heart-handshake",
+        "donate": "hand-heart",
     };
 
     Icons.add = (newIcons) => {

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -3388,9 +3388,7 @@ define([
     UIElements.displayCrowdfunding = function (common, force) {
         if (crowdfundingState) { return; }
         var priv = common.getMetadataMgr().getPrivateData();
-        var inDrive = /^\/drive/;
-        var isDriveContext = inDrive.test(priv.pathname || '');
-        if (isDriveContext) { return; }
+        if (priv.app === 'drive') { return; }
         if (!priv.channel) { return; }
         if (priv.app === 'form' && priv.readOnly && !priv.form_auditorHash && !priv.form_auditorKey) { return; }
 

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -3394,7 +3394,7 @@ define([
         if (!priv.channel) { return; }
         if (priv.app === 'form' && priv.readOnly && !priv.form_auditorHash && !priv.form_auditorKey) { return; }
 
-        var todo = function (actionCount) {
+        var todo = function () {
             crowdfundingState = true;
             var dontShowAgain = function () {
                 common.setAttribute(['general', 'crowdfunding'], false);
@@ -3450,12 +3450,11 @@ define([
                 buttons: buttons
             });
             UI.openCustomModal(modal, { wide: true });
-            common.getSframeChannel().query('Q_RECORD_CROWDFUNDING_SHOWN', { count: actionCount }, function () {});
         };
 
         if (force) {
             crowdfundingState = true;
-            return void todo(0);
+            return void todo();
         }
 
         if (AppConfig.disableCrowdfundingMessages) { return; }
@@ -3470,7 +3469,8 @@ define([
                     crowdfundingState = false;
                     return;
                 }
-                todo(result.actionCount);
+                todo();
+                common.getSframeChannel().query('Q_RECORD_CROWDFUNDING_SHOWN', {}, function () {});
             });
         });
     };

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -3460,7 +3460,7 @@ define([
 
         crowdfundingState = true;
         common.getAttribute(['general', 'crowdfunding'], function (err, val) {
-            if (err || val === false) { crowdfundingState = false; return; }
+            if ((err && common.isLoggedIn()) || val === false) { crowdfundingState = false; return; }
             common.getSframeChannel().query('Q_CROWDFUNDING_SHOULD_SHOW', null, function (err, result) {
                 if (err || !result || !result.show) {
                     crowdfundingState = false;

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -3460,7 +3460,7 @@ define([
 
         crowdfundingState = true;
         common.getAttribute(['general', 'crowdfunding'], function (err, val) {
-            if ((err && common.isLoggedIn()) || val === false) { crowdfundingState = false; return; }
+            if (err || val === false) { crowdfundingState = false; return; }
             common.getSframeChannel().query('Q_CROWDFUNDING_SHOULD_SHOW', null, function (err, result) {
                 if (err || !result || !result.show) {
                     crowdfundingState = false;

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -3399,9 +3399,7 @@ define([
                 Feedback.send('CROWDFUNDING_NEVER');
             };
 
-            var msgEl = h('div.msg');
-            UI.setHTML(msgEl, Messages.crowdfunding_popup_text);
-            var content = h('div', [msgEl]);
+            var content = Messages.crowdfunding_popup_text;
             var buttons = [
                 {
                     name: Messages.crowdfunding_popup_no,
@@ -3412,6 +3410,17 @@ define([
                     }
                 }
             ];
+            if (!Config.removeDonateButton) {
+                buttons.push({
+                    name: Messages.crowdfunding_button2,
+                    className: 'primary',
+                    iconClass: 'crowdfunding-donate',
+                    onClick: function () {
+                        common.openURL(priv.accounts.donateURL);
+                        Feedback.send('CROWDFUNDING_YES');
+                    }
+                });
+            }
             if (Config.accounts_api && priv.accountName) {
                 buttons.push({
                     name: Messages.features_f_subscribe,
@@ -3420,17 +3429,6 @@ define([
                     onClick: function () {
                         common.openURL('/accounts/');
                         Feedback.send('CROWDFUNDING_SUBSCRIBE');
-                    }
-                });
-            }
-            if (!Config.removeDonateButton) {
-                buttons.push({
-                    name: 'OpenCollective',
-                    className: 'primary',
-                    iconClass: 'donate',
-                    onClick: function () {
-                        common.openURL(priv.accounts.donateURL);
-                        Feedback.send('CROWDFUNDING_YES');
                     }
                 });
             }
@@ -3443,8 +3441,8 @@ define([
                 }
             });
             var modal = UI.dialog.customModal(content, {
+                force: true,
                 scrollable: true,
-                rawContent: true,
                 buttons: buttons
             });
             UI.openCustomModal(modal, { wide: true });

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -3432,7 +3432,7 @@ define([
                     }
                 });
             }
-            if (Config.accounts_api && priv.accountName) {
+            if (Config.accounts_api && common.isLoggedIn()) {
                 content += ' ' + Messages.crowdfunding_popup_text2;
                 buttons.push({
                     name: Messages.features_f_subscribe,

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -3403,17 +3403,23 @@ define([
             };
 
             var content = Messages.crowdfunding_popup_text;
-            var buttons = [
-                {
-                    name: Messages.crowdfunding_popup_no,
-                    className: 'cancel',
-                    iconClass: 'crowdfunding-snooze',
-                    onClick: function () {
-                        recordShown();
-                        Feedback.send('CROWDFUNDING_NO');
-                    }
+            var buttons = [{
+                name: Messages.dontShowAgain,
+                className: 'cancel left',
+                iconClass: 'close',
+                onClick: function () {
+                    recordShown();
+                    dontShowAgain();
                 }
-            ];
+            }, {
+                name: Messages.crowdfunding_popup_no,
+                className: 'cancel',
+                iconClass: 'crowdfunding-snooze',
+                onClick: function () {
+                    recordShown();
+                    Feedback.send('CROWDFUNDING_NO');
+                }
+            }];
             if (!Config.removeDonateButton) {
                 buttons.push({
                     name: Messages.crowdfunding_button2,
@@ -3439,20 +3445,12 @@ define([
                     }
                 });
             }
-            buttons.push({
-                name: Messages.dontShowAgain,
-                className: 'cancel left',
-                iconClass: 'close',
-                onClick: function () {
-                    recordShown();
-                    dontShowAgain();
-                }
-            });
             var modal = UI.dialog.customModal(content, {
                 force: true,
                 scrollable: true,
                 buttons: buttons
             });
+            $(modal).addClass('cp-crowdfunding-modal');
             UI.openCustomModal(modal, { wide: true });
         };
 

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -3422,6 +3422,7 @@ define([
                 });
             }
             if (Config.accounts_api && priv.accountName) {
+                content += ' ' + Messages.crowdfunding_popup_text2;
                 buttons.push({
                     name: Messages.features_f_subscribe,
                     className: 'primary',

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -3396,7 +3396,6 @@ define([
 
         var todo = function (actionCount) {
             crowdfundingState = true;
-            common.getSframeChannel().query('Q_RECORD_CROWDFUNDING_SHOWN', { count: actionCount }, function () {});
             var dontShowAgain = function () {
                 common.setAttribute(['general', 'crowdfunding'], false);
                 Feedback.send('CROWDFUNDING_NEVER');
@@ -3409,7 +3408,7 @@ define([
                 {
                     name: Messages.crowdfunding_popup_no,
                     className: 'cancel',
-                    iconClass: 'snooze',
+                    iconClass: 'crowdfunding-snooze',
                     onClick: function () {
                         Feedback.send('CROWDFUNDING_NO');
                     }
@@ -3451,6 +3450,7 @@ define([
                 buttons: buttons
             });
             UI.openCustomModal(modal, { wide: true });
+            common.getSframeChannel().query('Q_RECORD_CROWDFUNDING_SHOWN', { count: actionCount }, function () {});
         };
 
         if (force) {

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -944,7 +944,6 @@ define([
                             return void UI.warn(Messages.autostore_error);
                         }
                         $(document).trigger('cpPadStored');
-                        common.getSframeChannel().query('Q_INCREMENT_CROWDFUNDING_ACTION', null, function () {});
                         UI.log(Messages.autostore_saved);
                     });
                 });
@@ -3389,7 +3388,11 @@ define([
     UIElements.displayCrowdfunding = function (common, force) {
         if (crowdfundingState) { return; }
         var priv = common.getMetadataMgr().getPrivateData();
-        if (priv.app === 'form' && !priv.canEdit && !priv.form_auditorKey) { return; }
+        var inDrive = /^\/drive/;
+        var isDriveContext = inDrive.test(priv.pathname || '');
+        if (isDriveContext) { return; }
+        if (!priv.channel) { return; }
+        if (priv.app === 'form' && priv.readOnly && !priv.form_auditorHash && !priv.form_auditorKey) { return; }
 
         var todo = function (actionCount) {
             crowdfundingState = true;
@@ -3416,7 +3419,7 @@ define([
                 buttons.push({
                     name: Messages.features_f_subscribe,
                     className: 'primary',
-                    iconClass: 'subscribe',
+                    iconClass: 'crowdfunding-donate2',
                     onClick: function () {
                         common.openURL('/accounts/');
                         Feedback.send('CROWDFUNDING_SUBSCRIBE');
@@ -3487,7 +3490,7 @@ define([
 
         // This pad will be deleted automatically, it shouldn't be stored
         if (priv.burnAfterReading) { return; }
-        if (priv.app === 'form' && !priv.canEdit && !priv.form_auditorKey && !common.isLoggedIn()) { return; }
+        if (priv.app === 'form' && priv.readOnly && !priv.form_auditorHash && !priv.form_auditorKey && !common.isLoggedIn()) { return; }
         var typeMsg = priv.pathname.indexOf('/file/') !== -1 ? Messages.autostore_file :
                         priv.pathname.indexOf('/drive/') !== -1 ? Messages.autostore_sf :
                           Messages.autostore_pad;
@@ -3537,7 +3540,6 @@ define([
                     return void UI.warn(Messages.autostore_error);
                 }
                 $(document).trigger('cpPadStored');
-                common.getSframeChannel().query('Q_INCREMENT_CROWDFUNDING_ACTION', null, function () {});
                 delete autoStoreModal[priv.channel];
                 modal.delete();
                 UI.log(Messages.autostore_saved);

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -3394,6 +3394,9 @@ define([
 
         var todo = function () {
             crowdfundingState = true;
+            var recordShown = function () {
+                common.getSframeChannel().query('Q_RECORD_CROWDFUNDING_SHOWN', {}, function () {});
+            };
             var dontShowAgain = function () {
                 common.setAttribute(['general', 'crowdfunding'], false);
                 Feedback.send('CROWDFUNDING_NEVER');
@@ -3406,6 +3409,7 @@ define([
                     className: 'cancel',
                     iconClass: 'crowdfunding-snooze',
                     onClick: function () {
+                        recordShown();
                         Feedback.send('CROWDFUNDING_NO');
                     }
                 }
@@ -3416,6 +3420,7 @@ define([
                     className: 'primary',
                     iconClass: 'crowdfunding-donate',
                     onClick: function () {
+                        recordShown();
                         common.openURL(priv.accounts.donateURL);
                         Feedback.send('CROWDFUNDING_YES');
                     }
@@ -3428,6 +3433,7 @@ define([
                     className: 'primary',
                     iconClass: 'crowdfunding-donate2',
                     onClick: function () {
+                        recordShown();
                         common.openURL('/accounts/');
                         Feedback.send('CROWDFUNDING_SUBSCRIBE');
                     }
@@ -3438,6 +3444,7 @@ define([
                 className: 'cancel left',
                 iconClass: 'close',
                 onClick: function () {
+                    recordShown();
                     dontShowAgain();
                 }
             });
@@ -3467,7 +3474,6 @@ define([
                     return;
                 }
                 todo();
-                common.getSframeChannel().query('Q_RECORD_CROWDFUNDING_SHOWN', {}, function () {});
             });
         });
     };

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -3406,6 +3406,7 @@ define([
                 {
                     name: Messages.crowdfunding_popup_no,
                     className: 'cancel',
+                    iconClass: 'snooze',
                     onClick: function () {
                         Feedback.send('CROWDFUNDING_NO');
                     }
@@ -3413,7 +3414,7 @@ define([
             ];
             if (Config.accounts_api && priv.accountName) {
                 buttons.push({
-                    name: Messages.crowdfunding_subscribe,
+                    name: Messages.features_f_subscribe,
                     className: 'primary',
                     iconClass: 'subscribe',
                     onClick: function () {

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -3411,7 +3411,7 @@ define([
                     }
                 }
             ];
-            if (Config.accounts_api) {
+            if (Config.accounts_api && priv.accountName) {
                 buttons.push({
                     name: Messages.crowdfunding_subscribe,
                     className: 'primary',

--- a/www/common/common-ui-elements.js
+++ b/www/common/common-ui-elements.js
@@ -944,6 +944,7 @@ define([
                             return void UI.warn(Messages.autostore_error);
                         }
                         $(document).trigger('cpPadStored');
+                        common.getSframeChannel().query('Q_INCREMENT_CROWDFUNDING_ACTION', null, function () {});
                         UI.log(Messages.autostore_saved);
                     });
                 });
@@ -3390,54 +3391,82 @@ define([
         var priv = common.getMetadataMgr().getPrivateData();
         if (priv.app === 'form' && !priv.canEdit && !priv.form_auditorKey) { return; }
 
-        var todo = function () {
+        var todo = function (actionCount) {
             crowdfundingState = true;
-            // Display the popup
-            var text = Messages.crowdfunding_popup_text;
-            var yes = h('button.cp-corner-primary', [
-                Icons.get('external-link'),
-                'OpenCollective'
-            ]);
-            var no = h('button.cp-corner-cancel', Messages.crowdfunding_popup_no);
-            var actions = h('div', [no, yes]);
-
+            common.getSframeChannel().query('Q_RECORD_CROWDFUNDING_SHOWN', { count: actionCount }, function () {});
             var dontShowAgain = function () {
                 common.setAttribute(['general', 'crowdfunding'], false);
                 Feedback.send('CROWDFUNDING_NEVER');
             };
 
-            var modal = UI.cornerPopup(text, actions, '', {
-                big: true,
-                alt: true,
-                dontShowAgain: dontShowAgain
+            var msgEl = h('div.msg');
+            UI.setHTML(msgEl, Messages.crowdfunding_popup_text);
+            var content = h('div', [msgEl]);
+            var buttons = [
+                {
+                    name: Messages.crowdfunding_popup_no,
+                    className: 'cancel',
+                    onClick: function () {
+                        Feedback.send('CROWDFUNDING_NO');
+                    }
+                }
+            ];
+            if (Config.accounts_api) {
+                buttons.push({
+                    name: Messages.crowdfunding_subscribe,
+                    className: 'primary',
+                    iconClass: 'subscribe',
+                    onClick: function () {
+                        common.openURL('/accounts/');
+                        Feedback.send('CROWDFUNDING_SUBSCRIBE');
+                    }
+                });
+            }
+            if (!Config.removeDonateButton) {
+                buttons.push({
+                    name: 'OpenCollective',
+                    className: 'primary',
+                    iconClass: 'donate',
+                    onClick: function () {
+                        common.openURL(priv.accounts.donateURL);
+                        Feedback.send('CROWDFUNDING_YES');
+                    }
+                });
+            }
+            buttons.push({
+                name: Messages.dontShowAgain,
+                className: 'cancel left',
+                iconClass: 'close',
+                onClick: function () {
+                    dontShowAgain();
+                }
             });
-
-            $(yes).click(function () {
-                modal.delete();
-                common.openURL(priv.accounts.donateURL);
-                Feedback.send('CROWDFUNDING_YES');
+            var modal = UI.dialog.customModal(content, {
+                scrollable: true,
+                rawContent: true,
+                buttons: buttons
             });
-            $(no).click(function () {
-                modal.delete();
-                Feedback.send('CROWDFUNDING_NO');
-            });
+            UI.openCustomModal(modal, { wide: true });
         };
 
         if (force) {
             crowdfundingState = true;
-            return void todo();
+            return void todo(0);
         }
 
         if (AppConfig.disableCrowdfundingMessages) { return; }
         if (priv.plan) { return; }
+        if (Config.removeDonateButton && !Config.accounts_api) { return; }
 
         crowdfundingState = true;
         common.getAttribute(['general', 'crowdfunding'], function (err, val) {
-            if (err || val === false) { return; }
-            common.getSframeChannel().query('Q_GET_PINNED_USAGE', null, function (err, obj) {
-                var quotaMb = obj.quota / (1024 * 1024);
-                if (quotaMb < 10) { return; }
-                todo();
+            if (err || val === false) { crowdfundingState = false; return; }
+            common.getSframeChannel().query('Q_CROWDFUNDING_SHOULD_SHOW', null, function (err, result) {
+                if (err || !result || !result.show) {
+                    crowdfundingState = false;
+                    return;
+                }
+                todo(result.actionCount);
             });
         });
     };
@@ -3507,6 +3536,7 @@ define([
                     return void UI.warn(Messages.autostore_error);
                 }
                 $(document).trigger('cpPadStored');
+                common.getSframeChannel().query('Q_INCREMENT_CROWDFUNDING_ACTION', null, function () {});
                 delete autoStoreModal[priv.channel];
                 modal.delete();
                 UI.log(Messages.autostore_saved);

--- a/www/common/outer/local-store.js
+++ b/www/common/outer/local-store.js
@@ -153,7 +153,7 @@ define([
             Object.keys(localStorage || {}).forEach(function (k) {
                 // Remove everything in localStorage except CACHE and FS_hash
                 if (/^CRYPTPAD_CACHE/.test(k) || /^LESS_CACHE/.test(k) || k === Constants.fileHashKey || /^CRYPTPAD_STORE|colortheme/.test(k) || (!isDeletion && /^cp_crowdfunding_/.test(k))) { return; }
-                localStorage.removeItem(k);
+                delete localStorage[k];
             });
         } catch (e) { console.error(e); }
         LocalStore.clearThumbnail();

--- a/www/common/outer/local-store.js
+++ b/www/common/outer/local-store.js
@@ -152,7 +152,7 @@ define([
         try {
             Object.keys(localStorage || {}).forEach(function (k) {
                 // Remove everything in localStorage except CACHE and FS_hash
-                if (/^CRYPTPAD_CACHE/.test(k) || /^LESS_CACHE/.test(k) || k === Constants.fileHashKey || /^CRYPTPAD_STORE|colortheme/.test(k) || /^cp_crowdfunding_/.test(k)) { return; }
+                if (/^CRYPTPAD_CACHE/.test(k) || /^LESS_CACHE/.test(k) || k === Constants.fileHashKey || /^CRYPTPAD_STORE|colortheme/.test(k) || (!isDeletion && /^cp_crowdfunding_/.test(k))) { return; }
                 localStorage.removeItem(k);
             });
         } catch (e) { console.error(e); }

--- a/www/common/outer/local-store.js
+++ b/www/common/outer/local-store.js
@@ -151,9 +151,9 @@ define([
         sessionStorage.clear();
         try {
             Object.keys(localStorage || {}).forEach(function (k) {
-                // Remvoe everything in localStorage except CACHE and FS_hash
-                if (/^CRYPTPAD_CACHE/.test(k) || /^LESS_CACHE/.test(k) || k === Constants.fileHashKey || /^CRYPTPAD_STORE|colortheme/.test(k)) { return; }
-                delete localStorage[k];
+                // Remove everything in localStorage except CACHE and FS_hash
+                if (/^CRYPTPAD_CACHE/.test(k) || /^LESS_CACHE/.test(k) || k === Constants.fileHashKey || /^CRYPTPAD_STORE|colortheme/.test(k) || /^cp_crowdfunding_/.test(k)) { return; }
+                localStorage.removeItem(k);
             });
         } catch (e) { console.error(e); }
         LocalStore.clearThumbnail();

--- a/www/common/sframe-common-outer.js
+++ b/www/common/sframe-common-outer.js
@@ -1020,7 +1020,7 @@ define([
                 var CROWDFUNDING_PREFIX = 'cp_crowdfunding_';
                 var CROWDFUNDING_DRIVE_KEY = ['general', 'crowdfunding_metrics'];
                 // First action (opening or creating a document) count threshold before showing the banner
-                var CROWDFUNDING_MIN_ACTIONS = 10;
+                var CROWDFUNDING_MIN_ACTIONS = 5;
                 // Additional actions required after each shown banner
                 var CROWDFUNDING_ACTIONS_INTERVAL = 15;
                 // Quota usage threshold for quota-based banner display

--- a/www/common/sframe-common-outer.js
+++ b/www/common/sframe-common-outer.js
@@ -1019,13 +1019,13 @@ define([
                 });
                 var CROWDFUNDING_PREFIX = 'cp_crowdfunding_';
                 var CROWDFUNDING_DRIVE_KEY = ['general', 'crowdfunding_metrics'];
-                // First action count threshold before showing the banner (10 actions)
+                // First action (opening or creating a document) count threshold before showing the banner
                 var CROWDFUNDING_MIN_ACTIONS = 10;
-                // Additional actions required after each shown banner (15 actions)
+                // Additional actions required after each shown banner
                 var CROWDFUNDING_ACTIONS_INTERVAL = 15;
-                // Quota usage threshold for quota-based banner display (10 MB)
+                // Quota usage threshold for quota-based banner display
                 var CROWDFUNDING_MIN_QUOTA_MB = 10;
-                // Cooldown between banner displays based on last shown timestamp (24 hours)
+                // Cooldown between banner displays based on last shown timestamp
                 var CROWDFUNDING_ONE_DAY_MS = 24 * 60 * 60 * 1000;
                 var crowdfundingGetLS = function () {
                     var get = function (suffix) {

--- a/www/common/sframe-common-outer.js
+++ b/www/common/sframe-common-outer.js
@@ -1018,65 +1018,135 @@ define([
                     });
                 });
                 var CROWDFUNDING_PREFIX = 'cp_crowdfunding_';
-                var CROWDFUNDING_LEGACY = { visitCount: 'cp_crowdfundingVisitCount', firstSeen: 'cp_crowdfundingFirstSeen', lastShownAtCount: 'cp_crowdfundingLastShownAtCount', lastShownAtTime: 'cp_crowdfundingLastShownAtTime' };
-                var crowdfundingKey = function (suffix) {
-                    return CROWDFUNDING_PREFIX + suffix;
-                };
-                var crowdfundingGet = function (suffix) {
-                    var k = crowdfundingKey(suffix);
-                    var val = localStorage.getItem(k);
-                    if (val !== null && val !== '') return val;
-                    var legacy = CROWDFUNDING_LEGACY[suffix];
-                    if (legacy) {
-                        val = localStorage.getItem(legacy);
-                        if (val !== null && val !== '') {
-                            try { localStorage.setItem(k, val); localStorage.removeItem(legacy); } catch (e) {}
-                            return val;
-                        }
-                    }
-                    return null;
-                };
-                var CROWDFUNDING_MIN_ACTIONS = 5;
-                var CROWDFUNDING_ACTIONS_INTERVAL = 10;
+                var CROWDFUNDING_DRIVE_KEY = ['general', 'crowdfunding_metrics'];
+                var CROWDFUNDING_MIN_ACTIONS = 10;
+                var CROWDFUNDING_ACTIONS_INTERVAL = 15;
                 var CROWDFUNDING_MIN_QUOTA_MB = 10;
                 var CROWDFUNDING_ONE_DAY_MS = 24 * 60 * 60 * 1000;
+                var CROWDFUNDING_OPEN_DEDUPE_MS = 15000;
+                var crowdfundingLastOpenScope = null;
+                var crowdfundingLastOpenAt = 0;
+                var crowdfundingGetLS = function () {
+                    var get = function (suffix) {
+                        var k = CROWDFUNDING_PREFIX + suffix;
+                        var val = localStorage.getItem(k);
+                        if (val !== null && val !== '') { return Number(val) || null; }
+                        return null;
+                    };
+                    return {
+                        visitCount: get('visitCount') || 0,
+                        firstSeen: get('firstSeen') || null,
+                        lastShownAtCount: get('lastShownAtCount') || 0,
+                        lastShownAtTime: get('lastShownAtTime') || 0
+                    };
+                };
+                // Read metrics: encrypted drive for logged-in users, localStorage for guests
+                var crowdfundingReadMetrics = function (cb) {
+                    if (!Utils.LocalStore.isLoggedIn()) { return cb(crowdfundingGetLS()); }
+                    Cryptpad.getAttribute(CROWDFUNDING_DRIVE_KEY, function (e, metrics) {
+                        if (e || !metrics || typeof metrics !== 'object') {
+                            return cb(crowdfundingGetLS());
+                        }
+                        cb(metrics);
+                    });
+                };
+                // Write metrics: encrypted drive for logged-in users, localStorage for guests
+                var crowdfundingWriteMetrics = function (metrics, cb) {
+                    if (!Utils.LocalStore.isLoggedIn()) {
+                        try {
+                            ['visitCount', 'firstSeen', 'lastShownAtCount', 'lastShownAtTime'].forEach(function (k) {
+                                if (metrics[k] !== null && metrics[k] !== undefined) {
+                                    localStorage.setItem(CROWDFUNDING_PREFIX + k, String(metrics[k]));
+                                }
+                            });
+                        } catch (e) {}
+                        return cb && cb();
+                    }
+                    Cryptpad.setAttribute(CROWDFUNDING_DRIVE_KEY, metrics, function (e) {
+                        if (!e) {
+                            return cb && cb();
+                        }
+                        try {
+                            ['visitCount', 'firstSeen', 'lastShownAtCount', 'lastShownAtTime'].forEach(function (k) {
+                                if (metrics[k] !== null && metrics[k] !== undefined) {
+                                    localStorage.setItem(CROWDFUNDING_PREFIX + k, String(metrics[k]));
+                                }
+                            });
+                        } catch (e) {}
+                        cb && cb();
+                    });
+                };
+                var crowdfundingIncrementAction = function (cb) {
+                    crowdfundingReadMetrics(function (metrics) {
+                        metrics.visitCount = (metrics.visitCount || 0) + 1;
+                        if (!metrics.firstSeen) { metrics.firstSeen = Date.now(); }
+                        crowdfundingWriteMetrics(metrics, cb);
+                    });
+                };
 
                 sframeChan.on('Q_CROWDFUNDING_SHOULD_SHOW', function (data, cb) {
-                    var check = function () {
-                        var actionCount = Number(crowdfundingGet('visitCount')) || 0;
-                        var lastShownAtCount = Number(crowdfundingGet('lastShownAtCount')) || 0;
-                        var lastShownAtTime = Number(crowdfundingGet('lastShownAtTime')) || 0;
+                    crowdfundingReadMetrics(function (metrics) {
+                        var actionCount = metrics.visitCount || 0;
+                        var lastShownAtCount = metrics.lastShownAtCount || 0;
+                        var lastShownAtTime = metrics.lastShownAtTime || 0;
                         var now = Date.now();
                         var nextThreshold = lastShownAtCount === 0 ? CROWDFUNDING_MIN_ACTIONS : lastShownAtCount + CROWDFUNDING_ACTIONS_INTERVAL;
                         var enoughTimePassed = lastShownAtTime === 0 || (now - lastShownAtTime >= CROWDFUNDING_ONE_DAY_MS);
-                        cb({
-                            show: actionCount >= nextThreshold && enoughTimePassed,
-                            actionCount: actionCount
-                        });
-                    };
-                    if (CROWDFUNDING_MIN_QUOTA_MB <= 0) { return check(); }
-                    Cryptpad.getPinnedUsage({}, function (e, used) {
-                        if (e || typeof used !== 'number' || (used / (1024 * 1024)) < CROWDFUNDING_MIN_QUOTA_MB) {
-                            return cb({ show: false });
+                        var showFromActions = actionCount >= nextThreshold && enoughTimePassed;
+                        if (showFromActions) {
+                            return cb({
+                                show: true,
+                                actionCount: actionCount
+                            });
                         }
-                        check();
+                        if (CROWDFUNDING_MIN_QUOTA_MB <= 0) {
+                            return cb({
+                                show: false,
+                                actionCount: actionCount
+                            });
+                        }
+                        Cryptpad.getPinnedUsage({}, function (e, used) {
+                            var usedMb = (typeof used === 'number') ? (used / (1024 * 1024)) : 0;
+                            cb({
+                                show: !e && usedMb >= CROWDFUNDING_MIN_QUOTA_MB && enoughTimePassed,
+                                actionCount: actionCount
+                            });
+                        });
                     });
                 });
                 sframeChan.on('Q_RECORD_CROWDFUNDING_SHOWN', function (data, cb) {
-                    try {
-                        if (data && typeof data.count === 'number') localStorage.setItem(crowdfundingKey('lastShownAtCount'), String(data.count));
-                        localStorage.setItem(crowdfundingKey('lastShownAtTime'), String(Date.now()));
-                    } catch (e) { console.warn('crowdfunding write failed', e); }
-                    cb();
+                    crowdfundingReadMetrics(function (metrics) {
+                        if (data && typeof data.count === 'number') { metrics.lastShownAtCount = data.count; }
+                        metrics.lastShownAtTime = Date.now();
+                        crowdfundingWriteMetrics(metrics, cb);
+                    });
                 });
-                sframeChan.on('Q_INCREMENT_CROWDFUNDING_ACTION', function (data, cb) {
+                sframeChan.on('Q_CROWDFUNDING_INCREMENT_OPEN', function (data, cb) {
+                    if (readOnly) { return cb && cb(); }
+                    var requestedScope = data && data.scope;
+                    var scope = (secret && secret.channel) || requestedScope;
+                    if (!scope) { return cb && cb(); }
+                    var now = Date.now();
+                    if (crowdfundingLastOpenScope === scope &&
+                        (now - crowdfundingLastOpenAt) < CROWDFUNDING_OPEN_DEDUPE_MS) {
+                        return cb && cb();
+                    }
                     try {
-                        var k = crowdfundingKey('visitCount');
-                        var count = (Number(localStorage.getItem(k)) || 0) + 1;
-                        localStorage.setItem(k, String(count));
-                        if (count === 1) localStorage.setItem(crowdfundingKey('firstSeen'), String(Date.now()));
-                    } catch (e) { console.warn('crowdfunding write failed', e); }
-                    cb();
+                        var dedupeRaw = localStorage.getItem(CROWDFUNDING_PREFIX + 'open_dedupe');
+                        var dedupe = dedupeRaw ? JSON.parse(dedupeRaw) : null;
+                        if (dedupe && dedupe.scope === scope &&
+                            typeof dedupe.ts === 'number' &&
+                            (now - dedupe.ts) < CROWDFUNDING_OPEN_DEDUPE_MS) {
+                            return cb && cb();
+                        }
+                        localStorage.setItem(CROWDFUNDING_PREFIX + 'open_dedupe', JSON.stringify({
+                            scope: scope,
+                            ts: now
+                        }));
+                    } catch (e) {}
+                    crowdfundingLastOpenScope = scope;
+                    crowdfundingLastOpenAt = now;
+                    crowdfundingIncrementAction(cb);
                 });
 
                 Cryptpad.mailbox.onEvent.reg(function (data, cb) {
@@ -2381,12 +2451,6 @@ define([
 
             sframeChan.on('Q_CREATE_PAD', function (data, cb) {
                 if (!isNewFile || rtStarted) { return; }
-                try {
-                    var k = 'cp_crowdfunding_visitCount';
-                    var count = (Number(localStorage.getItem(k)) || 0) + 1;
-                    localStorage.setItem(k, String(count));
-                    if (count === 1) localStorage.setItem('cp_crowdfunding_firstSeen', String(Date.now()));
-                } catch (e) { console.warn('crowdfunding write failed', e); }
                 let feedbackKey = 'APP_' + parsed.type.toUpperCase() + '_CREATE';
                 Utils.Feedback.send(feedbackKey);
                 // Create a new hash

--- a/www/common/sframe-common-outer.js
+++ b/www/common/sframe-common-outer.js
@@ -1019,13 +1019,14 @@ define([
                 });
                 var CROWDFUNDING_PREFIX = 'cp_crowdfunding_';
                 var CROWDFUNDING_DRIVE_KEY = ['general', 'crowdfunding_metrics'];
+                // First action count threshold before showing the banner (10 actions)
                 var CROWDFUNDING_MIN_ACTIONS = 10;
+                // Additional actions required after each shown banner (15 actions)
                 var CROWDFUNDING_ACTIONS_INTERVAL = 15;
+                // Quota usage threshold for quota-based banner display (10 MB)
                 var CROWDFUNDING_MIN_QUOTA_MB = 10;
+                // Cooldown between banner displays based on last shown timestamp (24 hours)
                 var CROWDFUNDING_ONE_DAY_MS = 24 * 60 * 60 * 1000;
-                var CROWDFUNDING_OPEN_DEDUPE_MS = 15000;
-                var crowdfundingLastOpenScope = null;
-                var crowdfundingLastOpenAt = 0;
                 var crowdfundingGetLS = function () {
                     var get = function (suffix) {
                         var k = CROWDFUNDING_PREFIX + suffix;
@@ -1111,38 +1112,13 @@ define([
                 });
                 sframeChan.on('Q_RECORD_CROWDFUNDING_SHOWN', function (data, cb) {
                     crowdfundingReadMetrics(function (metrics) {
-                        if (data && typeof data.count === 'number') { metrics.lastShownAtCount = data.count; }
+                        metrics.lastShownAtCount = (data && typeof data.count === 'number') ? data.count : (metrics.visitCount || 0);
                         metrics.lastShownAtTime = Date.now();
                         crowdfundingWriteMetrics(metrics, cb);
                     });
                 });
                 sframeChan.on('Q_CROWDFUNDING_INCREMENT_OPEN', function (data, cb) {
                     if (readOnly) { return cb && cb(); }
-                    var requestedScope = data && data.scope;
-                    var scope = (secret && secret.channel) || requestedScope;
-                    if (!scope) { return cb && cb(); }
-                    var now = Date.now();
-                    if (crowdfundingLastOpenScope === scope &&
-                        (now - crowdfundingLastOpenAt) < CROWDFUNDING_OPEN_DEDUPE_MS) {
-                        return cb && cb();
-                    }
-                    try {
-                        var dedupeRaw = localStorage.getItem(CROWDFUNDING_PREFIX + 'open_dedupe');
-                        var dedupe = dedupeRaw ? JSON.parse(dedupeRaw) : null;
-                        if (dedupe && dedupe.scope === scope &&
-                            typeof dedupe.ts === 'number' &&
-                            (now - dedupe.ts) < CROWDFUNDING_OPEN_DEDUPE_MS) {
-                            return cb && cb();
-                        }
-                        localStorage.setItem(CROWDFUNDING_PREFIX + 'open_dedupe', JSON.stringify({
-                            scope: scope,
-                            ts: now
-                        }));
-                    } catch (e) {
-                        try { localStorage.removeItem(CROWDFUNDING_PREFIX + 'open_dedupe'); } catch (e2) {}
-                    }
-                    crowdfundingLastOpenScope = scope;
-                    crowdfundingLastOpenAt = now;
                     crowdfundingIncrementAction(cb);
                 });
 

--- a/www/common/sframe-common-outer.js
+++ b/www/common/sframe-common-outer.js
@@ -1045,7 +1045,12 @@ define([
                     if (!Utils.LocalStore.isLoggedIn()) { return cb(crowdfundingGetLS()); }
                     Cryptpad.getAttribute(CROWDFUNDING_DRIVE_KEY, function (e, metrics) {
                         if (e || !metrics || typeof metrics !== 'object') {
-                            return cb(crowdfundingGetLS());
+                            return cb({
+                                visitCount: 0,
+                                firstSeen: null,
+                                lastShownAtCount: 0,
+                                lastShownAtTime: 0
+                            });
                         }
                         cb(metrics);
                     });
@@ -1062,17 +1067,7 @@ define([
                         } catch (e) {}
                         return cb && cb();
                     }
-                    Cryptpad.setAttribute(CROWDFUNDING_DRIVE_KEY, metrics, function (e) {
-                        if (!e) {
-                            return cb && cb();
-                        }
-                        try {
-                            ['visitCount', 'firstSeen', 'lastShownAtCount', 'lastShownAtTime'].forEach(function (k) {
-                                if (metrics[k] !== null && metrics[k] !== undefined) {
-                                    localStorage.setItem(CROWDFUNDING_PREFIX + k, String(metrics[k]));
-                                }
-                            });
-                        } catch (e) {}
+                    Cryptpad.setAttribute(CROWDFUNDING_DRIVE_KEY, metrics, function () {
                         cb && cb();
                     });
                 };
@@ -1143,7 +1138,9 @@ define([
                             scope: scope,
                             ts: now
                         }));
-                    } catch (e) {}
+                    } catch (e) {
+                        try { localStorage.removeItem(CROWDFUNDING_PREFIX + 'open_dedupe'); } catch (e2) {}
+                    }
                     crowdfundingLastOpenScope = scope;
                     crowdfundingLastOpenAt = now;
                     crowdfundingIncrementAction(cb);

--- a/www/common/sframe-common-outer.js
+++ b/www/common/sframe-common-outer.js
@@ -1024,9 +1024,9 @@ define([
                 // Additional actions required after each shown banner
                 var CROWDFUNDING_ACTIONS_INTERVAL = 15;
                 // Quota usage threshold for quota-based banner display
-                var CROWDFUNDING_MIN_QUOTA_MB = 10;
-                // Cooldown between banner displays based on last shown timestamp
-                var CROWDFUNDING_ONE_DAY_MS = 24 * 60 * 60 * 1000;
+                var CROWDFUNDING_MIN_QUOTA_MB = 50;
+                // Cooldown between banner displays based on last shown timestamp in milliseconds
+                var CROWDFUNDING_COOLDOWN_MS = 24 * 60 * 60 * 1000;
                 var crowdfundingGetLS = function () {
                     var get = function (suffix) {
                         var k = CROWDFUNDING_PREFIX + suffix;
@@ -1087,7 +1087,7 @@ define([
                         var lastShownAtTime = metrics.lastShownAtTime || 0;
                         var now = Date.now();
                         var nextThreshold = lastShownAtCount === 0 ? CROWDFUNDING_MIN_ACTIONS : lastShownAtCount + CROWDFUNDING_ACTIONS_INTERVAL;
-                        var enoughTimePassed = lastShownAtTime === 0 || (now - lastShownAtTime >= CROWDFUNDING_ONE_DAY_MS);
+                        var enoughTimePassed = lastShownAtTime === 0 || (now - lastShownAtTime >= CROWDFUNDING_COOLDOWN_MS);
                         var showFromActions = actionCount >= nextThreshold && enoughTimePassed;
                         if (showFromActions) {
                             return cb({

--- a/www/common/sframe-common-outer.js
+++ b/www/common/sframe-common-outer.js
@@ -1022,7 +1022,7 @@ define([
                 // First action (opening or creating a document) count threshold before showing the banner
                 var CROWDFUNDING_MIN_ACTIONS = 5;
                 // Additional actions required after each shown banner
-                var CROWDFUNDING_ACTIONS_INTERVAL = 15;
+                var CROWDFUNDING_ACTIONS_INTERVAL = 10;
                 // Quota usage threshold for quota-based banner display
                 var CROWDFUNDING_MIN_QUOTA_MB = 50;
                 // Cooldown between banner displays based on last shown timestamp in milliseconds

--- a/www/common/sframe-common-outer.js
+++ b/www/common/sframe-common-outer.js
@@ -1042,10 +1042,7 @@ define([
                 var CROWDFUNDING_ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
                 sframeChan.on('Q_CROWDFUNDING_SHOULD_SHOW', function (data, cb) {
-                    Cryptpad.getPinnedUsage({}, function (e, used) {
-                        if (e || typeof used !== 'number' || (used / (1024 * 1024)) < CROWDFUNDING_MIN_QUOTA_MB) {
-                            return cb({ show: false });
-                        }
+                    var check = function () {
                         var actionCount = Number(crowdfundingGet('visitCount')) || 0;
                         var lastShownAtCount = Number(crowdfundingGet('lastShownAtCount')) || 0;
                         var lastShownAtTime = Number(crowdfundingGet('lastShownAtTime')) || 0;
@@ -1056,6 +1053,13 @@ define([
                             show: actionCount >= nextThreshold && enoughTimePassed,
                             actionCount: actionCount
                         });
+                    };
+                    if (CROWDFUNDING_MIN_QUOTA_MB <= 0) { return check(); }
+                    Cryptpad.getPinnedUsage({}, function (e, used) {
+                        if (e || typeof used !== 'number' || (used / (1024 * 1024)) < CROWDFUNDING_MIN_QUOTA_MB) {
+                            return cb({ show: false });
+                        }
+                        check();
                     });
                 });
                 sframeChan.on('Q_RECORD_CROWDFUNDING_SHOWN', function (data, cb) {

--- a/www/common/sframe-common-outer.js
+++ b/www/common/sframe-common-outer.js
@@ -1017,6 +1017,63 @@ define([
                         cb({error:e});
                     });
                 });
+                var CROWDFUNDING_PREFIX = 'cp_crowdfunding_';
+                var CROWDFUNDING_LEGACY = { visitCount: 'cp_crowdfundingVisitCount', firstSeen: 'cp_crowdfundingFirstSeen', lastShownAtCount: 'cp_crowdfundingLastShownAtCount', lastShownAtTime: 'cp_crowdfundingLastShownAtTime' };
+                var crowdfundingKey = function (suffix) {
+                    return CROWDFUNDING_PREFIX + suffix;
+                };
+                var crowdfundingGet = function (suffix) {
+                    var k = crowdfundingKey(suffix);
+                    var val = localStorage.getItem(k);
+                    if (val !== null && val !== '') return val;
+                    var legacy = CROWDFUNDING_LEGACY[suffix];
+                    if (legacy) {
+                        val = localStorage.getItem(legacy);
+                        if (val !== null && val !== '') {
+                            try { localStorage.setItem(k, val); localStorage.removeItem(legacy); } catch (e) {}
+                            return val;
+                        }
+                    }
+                    return null;
+                };
+                var CROWDFUNDING_MIN_ACTIONS = 5;
+                var CROWDFUNDING_ACTIONS_INTERVAL = 10;
+                var CROWDFUNDING_MIN_QUOTA_MB = 10;
+                var CROWDFUNDING_ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+                sframeChan.on('Q_CROWDFUNDING_SHOULD_SHOW', function (data, cb) {
+                    Cryptpad.getPinnedUsage({}, function (e, used) {
+                        if (e || typeof used !== 'number' || (used / (1024 * 1024)) < CROWDFUNDING_MIN_QUOTA_MB) {
+                            return cb({ show: false });
+                        }
+                        var actionCount = Number(crowdfundingGet('visitCount')) || 0;
+                        var lastShownAtCount = Number(crowdfundingGet('lastShownAtCount')) || 0;
+                        var lastShownAtTime = Number(crowdfundingGet('lastShownAtTime')) || 0;
+                        var now = Date.now();
+                        var nextThreshold = lastShownAtCount === 0 ? CROWDFUNDING_MIN_ACTIONS : lastShownAtCount + CROWDFUNDING_ACTIONS_INTERVAL;
+                        var enoughTimePassed = lastShownAtTime === 0 || (now - lastShownAtTime >= CROWDFUNDING_ONE_DAY_MS);
+                        cb({
+                            show: actionCount >= nextThreshold && enoughTimePassed,
+                            actionCount: actionCount
+                        });
+                    });
+                });
+                sframeChan.on('Q_RECORD_CROWDFUNDING_SHOWN', function (data, cb) {
+                    try {
+                        if (data && typeof data.count === 'number') localStorage.setItem(crowdfundingKey('lastShownAtCount'), String(data.count));
+                        localStorage.setItem(crowdfundingKey('lastShownAtTime'), String(Date.now()));
+                    } catch (e) { console.warn('crowdfunding write failed', e); }
+                    cb();
+                });
+                sframeChan.on('Q_INCREMENT_CROWDFUNDING_ACTION', function (data, cb) {
+                    try {
+                        var k = crowdfundingKey('visitCount');
+                        var count = (Number(localStorage.getItem(k)) || 0) + 1;
+                        localStorage.setItem(k, String(count));
+                        if (count === 1) localStorage.setItem(crowdfundingKey('firstSeen'), String(Date.now()));
+                    } catch (e) { console.warn('crowdfunding write failed', e); }
+                    cb();
+                });
 
                 Cryptpad.mailbox.onEvent.reg(function (data, cb) {
                     sframeChan.query('EV_MAILBOX_EVENT', data, function (err, obj) {
@@ -2320,6 +2377,12 @@ define([
 
             sframeChan.on('Q_CREATE_PAD', function (data, cb) {
                 if (!isNewFile || rtStarted) { return; }
+                try {
+                    var k = 'cp_crowdfunding_visitCount';
+                    var count = (Number(localStorage.getItem(k)) || 0) + 1;
+                    localStorage.setItem(k, String(count));
+                    if (count === 1) localStorage.setItem('cp_crowdfunding_firstSeen', String(Date.now()));
+                } catch (e) { console.warn('crowdfunding write failed', e); }
                 let feedbackKey = 'APP_' + parsed.type.toUpperCase() + '_CREATE';
                 Utils.Feedback.send(feedbackKey);
                 // Create a new hash

--- a/www/common/sframe-common.js
+++ b/www/common/sframe-common.js
@@ -1067,17 +1067,11 @@ define([
                 UIElements.displayCrowdfunding(funcs);
             };
             var privateData = ctx.metadataMgr.getPrivateData();
-            var inDrive = /^\/drive/;
-            var isDriveContext = inDrive.test(privateData.pathname || '');
-            var isReadOnlyContext = Boolean(privateData.readOnly);
-            var isReadOnlyFormResponse = privateData.app === 'form' && !privateData.form_auditorKey && ((!privateData.canEdit) || (isReadOnlyContext && !privateData.form_auditorHash));
-            var openScope = privateData.channel;
-            if (isDriveContext || isReadOnlyFormResponse || !openScope) {
-                showCrowdfunding();
-            } else {
-                ctx.sframeChan.query('Q_CROWDFUNDING_INCREMENT_OPEN', {
-                    scope: openScope
-                }, showCrowdfunding);
+            var isDriveContext = privateData.app === 'drive';
+            var isReadOnlyFormResponse = privateData.app === 'form' && priv.readOnly && !priv.form_auditorHash && !priv.form_auditorKey;
+            var skipCrowdfunding = privateData.secureIframe === true || privateData.unsafeIframe === true || isReadOnlyFormResponse || isDriveContext;
+            if (!skipCrowdfunding) {
+                ctx.sframeChan.query('Q_CROWDFUNDING_INCREMENT_OPEN', showCrowdfunding);
             }
 
             ctx.sframeChan.ready();

--- a/www/common/sframe-common.js
+++ b/www/common/sframe-common.js
@@ -768,7 +768,7 @@ define([
                 // Ctrl+E: New pad modal
                 var priv = ctx.metadataMgr.getPrivateData();
                 if (e.which === 69 && isApp) {
-                    if (priv.app === 'form' && !priv.canEdit && !priv.form_auditorKey) { return; }
+                    if (priv.app === 'form' && priv.readOnly && !priv.form_auditorHash && !priv.form_auditorKey) { return; }
                     e.preventDefault();
                     return void funcs.createNewPadModal();
                 }
@@ -1063,9 +1063,25 @@ define([
                 document.title = title;
             });
 
-            ctx.sframeChan.query('Q_INCREMENT_CROWDFUNDING_ACTION', null, function () {
+            var showCrowdfunding = function () {
                 UIElements.displayCrowdfunding(funcs);
-            });
+            };
+            var privateData = ctx.metadataMgr.getPrivateData();
+            var inDrive = /^\/drive/;
+            var isDriveContext = inDrive.test(privateData.pathname || '');
+            var isReadOnlyContext = Boolean(privateData.readOnly);
+            var isReadOnlyFormResponse = privateData.app === 'form' &&
+                !privateData.form_auditorKey &&
+                ((!privateData.canEdit) ||
+                 (isReadOnlyContext && !privateData.form_auditorHash));
+            var openScope = privateData.channel;
+            if (isDriveContext || isReadOnlyFormResponse || !openScope) {
+                showCrowdfunding();
+            } else {
+                ctx.sframeChan.query('Q_CROWDFUNDING_INCREMENT_OPEN', {
+                    scope: openScope
+                }, showCrowdfunding);
+            }
 
             ctx.sframeChan.ready();
 

--- a/www/common/sframe-common.js
+++ b/www/common/sframe-common.js
@@ -1070,10 +1070,7 @@ define([
             var inDrive = /^\/drive/;
             var isDriveContext = inDrive.test(privateData.pathname || '');
             var isReadOnlyContext = Boolean(privateData.readOnly);
-            var isReadOnlyFormResponse = privateData.app === 'form' &&
-                !privateData.form_auditorKey &&
-                ((!privateData.canEdit) ||
-                 (isReadOnlyContext && !privateData.form_auditorHash));
+            var isReadOnlyFormResponse = privateData.app === 'form' && !privateData.form_auditorKey && ((!privateData.canEdit) || (isReadOnlyContext && !privateData.form_auditorHash));
             var openScope = privateData.channel;
             if (isDriveContext || isReadOnlyFormResponse || !openScope) {
                 showCrowdfunding();

--- a/www/common/sframe-common.js
+++ b/www/common/sframe-common.js
@@ -1068,10 +1068,10 @@ define([
             };
             var privateData = ctx.metadataMgr.getPrivateData();
             var isDriveContext = privateData.app === 'drive';
-            var isReadOnlyFormResponse = privateData.app === 'form' && priv.readOnly && !priv.form_auditorHash && !priv.form_auditorKey;
+            var isReadOnlyFormResponse = privateData.app === 'form' && privateData.readOnly && !privateData.form_auditorHash && !privateData.form_auditorKey;
             var skipCrowdfunding = privateData.secureIframe === true || privateData.unsafeIframe === true || isReadOnlyFormResponse || isDriveContext;
             if (!skipCrowdfunding) {
-                ctx.sframeChan.query('Q_CROWDFUNDING_INCREMENT_OPEN', showCrowdfunding);
+                ctx.sframeChan.query('Q_CROWDFUNDING_INCREMENT_OPEN', {}, showCrowdfunding);
             }
 
             ctx.sframeChan.ready();

--- a/www/common/sframe-common.js
+++ b/www/common/sframe-common.js
@@ -1063,11 +1063,8 @@ define([
                 document.title = title;
             });
 
-            funcs.isPadStored(function (err, val) {
-                if (err || !val) { return; }
-                ctx.sframeChan.query('Q_INCREMENT_CROWDFUNDING_ACTION', null, function () {
-                    UIElements.displayCrowdfunding(funcs);
-                });
+            ctx.sframeChan.query('Q_INCREMENT_CROWDFUNDING_ACTION', null, function () {
+                UIElements.displayCrowdfunding(funcs);
             });
 
             ctx.sframeChan.ready();

--- a/www/common/sframe-common.js
+++ b/www/common/sframe-common.js
@@ -1065,7 +1065,9 @@ define([
 
             funcs.isPadStored(function (err, val) {
                 if (err || !val) { return; }
-                UIElements.displayCrowdfunding(funcs);
+                ctx.sframeChan.query('Q_INCREMENT_CROWDFUNDING_ACTION', null, function () {
+                    UIElements.displayCrowdfunding(funcs);
+                });
             });
 
             ctx.sframeChan.ready();

--- a/www/logout/main.js
+++ b/www/logout/main.js
@@ -8,15 +8,7 @@ define([
     '/components/nthen/index.js',
 ], function (localForage, Cache, nThen) {
     nThen(function (w) {
-        // Preserve crowdfunding keys across logout so counters survive session changes
-        var crowdfundingEntries = Object.keys(localStorage).reduce(function (acc, k) {
-            if (/^cp_crowdfunding_/.test(k)) { acc[k] = localStorage.getItem(k); }
-            return acc;
-        }, {});
         localStorage.clear();
-        Object.keys(crowdfundingEntries).forEach(function (k) {
-            try { localStorage.setItem(k, crowdfundingEntries[k]); } catch (e) {}
-        });
         localForage.clear(w());
         Cache.clear(w());
     }).nThen(function () {

--- a/www/logout/main.js
+++ b/www/logout/main.js
@@ -8,7 +8,15 @@ define([
     '/components/nthen/index.js',
 ], function (localForage, Cache, nThen) {
     nThen(function (w) {
+        // Preserve crowdfunding keys across logout so counters survive session changes
+        var crowdfundingEntries = Object.keys(localStorage).reduce(function (acc, k) {
+            if (/^cp_crowdfunding_/.test(k)) { acc[k] = localStorage.getItem(k); }
+            return acc;
+        }, {});
         localStorage.clear();
+        Object.keys(crowdfundingEntries).forEach(function (k) {
+            try { localStorage.setItem(k, crowdfundingEntries[k]); } catch (e) {}
+        });
         localForage.clear(w());
         Cache.clear(w());
     }).nThen(function () {

--- a/www/unsafeiframe/main.js
+++ b/www/unsafeiframe/main.js
@@ -106,6 +106,7 @@ define([
                             origin: window.location.origin,
                             pathname: window.location.pathname,
                             feedbackAllowed: Utils.Feedback.state,
+                            unsafeIframe: true,
                         };
                         for (var k in additionalPriv) { metaObj.priv[k] = additionalPriv[k]; }
 


### PR DESCRIPTION
This PR makes the crowdfunding banner more effective at reaching users who are genuinely engaged with CryptPad, while giving them a cleaner and more actionable way to support the project.

- [x] Improve UI
- [x] The show logic now takes into account a user's actions regarding documents and drive
- [x] The banner is shown just once per day and following a strict procedure to be less intrusive
- [x] Banner text and actions are updated with each type of instance
- [x] Visit counters are now persisted across logout/login
- [x] Not related but fix icon stroke-width for guest drive grid view