### PR TITLE
Add text to support team notification

### DIFF
--- a/customize.dist/messages.js
+++ b/customize.dist/messages.js
@@ -134,6 +134,8 @@ define(req, function(AppConfig, Default, Language) {
         }
     };
 
+    Messages.support_moderatorNotification = "{0} has added you to the support team as a moderator" // XXX
+
     return Messages;
 
 });


### PR DESCRIPTION
- fixes #2217 (when a user is added to support team as a moderator, the notification they get is in plaintext as opposed to a JSON containing the command text and administrator's user info)