### PR TITLE
BurnAfterRead links don’t always delete the correct channels

### DIFF
--- a/www/common/inner/access.js
+++ b/www/common/inner/access.js
@@ -18,25 +18,6 @@ define([
              Messages, nThen, Icons) {
     var Access = {};
 
-    const getOtherChans = (priv, opts) => {
-        // "attributes" contains the additional channels that the other user
-        // has to store (rtChannel, answersChannels, lastVersion, lastCpHash)
-        // - opts.attributes when access modal is created from the drive
-        // - liveAttr when access modal is created from the document
-        let liveAttr = Util.clone(priv.propChannels || {});
-        delete liveAttr.channel;
-        let attributes = opts.attributes || liveAttr;
-
-        // "otherChan" contains the list of channels that should also receive
-        // the ownership changes
-        let otherChan = [];
-        if (attributes?.answersChannel) { otherChan.push(attributes.answersChannel); }
-        if (attributes?.rtChannel) { otherChan.push(attributes.rtChannel); }
-        if (!otherChan.length) { otherChan = undefined; }
-
-        return { otherChan, attributes };
-    };
-
     var getOwnersTab = function (Env, data, opts, _cb) {
         var cb = Util.once(Util.mkAsync(_cb));
         var common = Env.common;
@@ -58,7 +39,7 @@ define([
 
         opts = opts || {};
 
-        const { attributes, otherChan } = getOtherChans(priv, opts);
+        const { attributes, otherChan } = Modal.getOtherChans(priv, opts);
 
         var redrawAll = function () {};
 
@@ -458,7 +439,7 @@ define([
         var allowed = data.allowed || [];
         var teamOwner = data.teamId;
 
-        const { otherChan } = getOtherChans(priv, opts);
+        const { otherChan } = Modal.getOtherChans(priv, opts);
 
         var redrawAll = function () {};
 
@@ -868,7 +849,7 @@ define([
         var metadataMgr = common.getMetadataMgr();
         var priv = metadataMgr.getPrivateData();
 
-        const { otherChan } = getOtherChans(priv, opts);
+        const { otherChan } = Modal.getOtherChans(priv, opts);
 
         var $div = $(h('div.cp-share-columns'));
 

--- a/www/common/inner/common-modal.js
+++ b/www/common/inner/common-modal.js
@@ -33,6 +33,24 @@ define([
             if (redraw) { Env.evRedrawAll.fire(redraw); }
         }));
     };
+    Modal.getOtherChans = (priv, opts) => {
+        // "attributes" contains the additional channels that the other user
+        // has to store (rtChannel, answersChannels, lastVersion, lastCpHash)
+        // - opts.attributes when access modal is created from the drive
+        // - liveAttr when access modal is created from the document
+        let liveAttr = Util.clone(priv.propChannels || {});
+        delete liveAttr.channel;
+        let attributes = opts.attributes || liveAttr;
+
+        // "otherChan" contains the list of channels that should also receive
+        // the ownership changes
+        let otherChan = [];
+        if (attributes?.answersChannel) { otherChan.push(attributes.answersChannel); }
+        if (attributes?.rtChannel) { otherChan.push(attributes.rtChannel); }
+        if (!otherChan.length) { otherChan = undefined; }
+
+        return { otherChan, attributes };
+    };
     Modal.getPadData = function (Env, opts, _cb) {
         var cb = Util.once(Util.mkAsync(_cb));
         var common = Env.common;

--- a/www/common/inner/share.js
+++ b/www/common/inner/share.js
@@ -265,20 +265,16 @@ define([
         });
         return teams;
     };
-    var makeBurnAfterReadingUrl = function (common, href, channel, cb) {
+    var makeBurnAfterReadingUrl = function (common, href, channel, opts, cb) {
         var keyPair = Hash.generateSignPair();
         var parsed = Hash.parsePadUrl(href);
         var newHref = parsed.getUrl({
             ownerKey: keyPair.safeSignKey
         });
         var sframeChan = common.getSframeChannel();
-        var rtChannel;
+        const priv = common.getMetadataMgr().getPrivateData();
+        const { otherChan } = Modal.getOtherChans(priv, opts);
         nThen(function (waitFor) {
-            if (parsed.type !== "sheet") { return; }
-            common.getPadAttribute('rtChannel', waitFor(function (err, chan) {
-                rtChannel = chan;
-            }));
-        }).nThen(function (waitFor) {
             sframeChan.query('Q_SET_PAD_METADATA', {
                 channel: channel,
                 command: 'ADD_OWNERS',
@@ -289,15 +285,15 @@ define([
                     UI.warn(Messages.error);
                 }
             }));
-            if (rtChannel) {
+            otherChan?.forEach((chan) => {
                 sframeChan.query('Q_SET_PAD_METADATA', {
-                    channel: rtChannel,
+                    channel: chan,
                     command: 'ADD_OWNERS',
                     value: [keyPair.validateKey]
                 }, waitFor(function (err) {
                     if (err) { console.error(err); }
                 }));
-            }
+            });
         }).nThen(function () {
             cb(newHref);
         });
@@ -477,7 +473,7 @@ define([
                 name:  Messages.share_bar,
                 onClick: function () {
                     var barHref = origin + pathname + '#' + (hashes.viewHash || hashes.editHash);
-                    makeBurnAfterReadingUrl(common, barHref, opts.channel, function (url) {
+                    makeBurnAfterReadingUrl(common, barHref, opts.channel, opts, function (url) {
                         opts.burnAfterReadingUrl = url;
                         opts.$rights.find('input[type="radio"]').trigger('change');
                     });
@@ -685,7 +681,7 @@ define([
             if (burnAfterReading && !opts.burnAfterReadingUrl) {
                 if (cb) { // Called from the contacts tab, "share" button
                     var barHref = origin + pathname + '#' + (hashes.viewHash || hashes.editHash);
-                    return makeBurnAfterReadingUrl(common, barHref, channel, function (url) {
+                    return makeBurnAfterReadingUrl(common, barHref, channel, opts, function (url) {
                         cb(url);
                     });
                 }

--- a/www/common/inner/share.js
+++ b/www/common/inner/share.js
@@ -265,36 +265,28 @@ define([
         });
         return teams;
     };
-    var makeBurnAfterReadingUrl = function (common, href, channel, opts, cb) {
-        var keyPair = Hash.generateSignPair();
-        var parsed = Hash.parsePadUrl(href);
-        var newHref = parsed.getUrl({
+    const makeBurnAfterReadingUrl = (common, href, channel, opts, cb) => {
+        const keyPair = Hash.generateSignPair();
+        const parsed = Hash.parsePadUrl(href);
+        const newHref = parsed.getUrl({
             ownerKey: keyPair.safeSignKey
         });
-        var sframeChan = common.getSframeChannel();
+        const sframeChan = common.getSframeChannel();
         const priv = common.getMetadataMgr().getPrivateData();
         const { otherChan } = Modal.getOtherChans(priv, opts);
-        nThen(function (waitFor) {
+        nThen((waitFor) => {
             sframeChan.query('Q_SET_PAD_METADATA', {
                 channel: channel,
+                channels: otherChan,
                 command: 'ADD_OWNERS',
                 value: [keyPair.validateKey]
-            }, waitFor(function (err) {
+            }, waitFor((err) => {
                 if (err) {
                     waitFor.abort();
                     UI.warn(Messages.error);
                 }
             }));
-            otherChan?.forEach((chan) => {
-                sframeChan.query('Q_SET_PAD_METADATA', {
-                    channel: chan,
-                    command: 'ADD_OWNERS',
-                    value: [keyPair.validateKey]
-                }, waitFor(function (err) {
-                    if (err) { console.error(err); }
-                }));
-            });
-        }).nThen(function () {
+        }).nThen(() => {
             cb(newHref);
         });
     };


### PR DESCRIPTION
This PR includes a more generic code for “burn after read” link generation to take into account other parts of the documents that need to be deleted as well (for example the content of an office document).