### PR TITLE
Flip bell icon and update delete history message #2198

### DIFF
--- a/www/common/messenger-ui.js
+++ b/www/common/messenger-ui.js
@@ -543,12 +543,12 @@ define([
                 curve = __channel.curvePublic;
             }
 
-            var unmute = h('span', Icons.get('notification'), {
+            var unmute = h('span', Icons.get('mute'), {
                 class: 'cp-app-contacts-remove cp-unmute-icon',
                 title: Messages.contacts_unmute || 'unmute',
                 style: (curve && mutedUsers[curve]) ? undefined : 'display: none;'
             });
-            var mute = h('span', Icons.get('mute'), {
+            var mute = h('span', Icons.get('notification'), {
                 class: 'cp-app-contacts-remove cp-mute-icon',
                 title: Messages.contacts_mute || 'mute',
                 style: (curve && mutedUsers[curve]) ? 'display: none;' : undefined

--- a/www/common/translations/messages.json
+++ b/www/common/translations/messages.json
@@ -233,7 +233,7 @@
     "contacts_info3": "Double-click their icon to view their profile",
     "contacts_info4": "Either participant can clear permanently a chat history",
     "contacts_removeHistoryTitle": "Clean the chat history",
-    "contacts_confirmRemoveHistory": "Are you sure you want to permanently remove your chat history? Data cannot be restored",
+    "contacts_confirmRemoveHistory": "Are you sure you want to permanently remove the chat history? This will clear all messages for both participants. Data cannot be restored.",
     "contacts_removeHistoryServerError": "There was an error while removing your chat history. Try again later",
     "contacts_fetchHistory": "Retrieve older history",
     "contacts_rooms": "Rooms",


### PR DESCRIPTION
Hi! This PR aims to fix #2198 as following:

> the disclaimer about deleting messages should be updated to notify the user that messages will be deleted for both users

Message is now: 
<img width="829" height="314" alt="image" src="https://github.com/user-attachments/assets/eb516673-c47b-4182-a242-2d27f883127c" />

I'm not sure if Weblate updating is triggered via some hook or how you trigger a translation request, so I hope this is enough for it to show up there.

> the "mute contact" button should be changed, as it is misleading
> The "mute contact button" should be changed to a bell and the "unmute contact" button should be changed to a bell with a line through it

<img width="301" height="227" alt="image" src="https://github.com/user-attachments/assets/73fa2198-bfe4-443b-8a86-195540dbb4e5" />
<img width="288" height="235" alt="image" src="https://github.com/user-attachments/assets/911432db-d11b-471b-afbc-4f9b64fd9d71" />

I am not sure if you want to rename the icon(s) entirely, but if you do, i would suggest `bell` and `bell-off`, to keep it independent of the context where the icon is used (see the manage muted users button, vs the crossed bell button with Unmute as label).

I can do that too, in this PR or a separate one, if you think it's a good idea. 

Let me know what you think. Thanks!