### PR TITLE
Translations update from CryptPad Translations

### DIFF
--- a/www/common/translations/messages.fr.json
+++ b/www/common/translations/messages.fr.json
@@ -1877,5 +1877,9 @@
     "contacts_muted": "Masqué",
     "contacts_noFriends": "Votre liste de contacts est vide",
     "contacts_noFriendsInfo": "Commencez par <a>ajouter un contact</a> pour débuter une conversation.",
-    "contacts_historyCleared": "L'historique de conversation a été supprimé pour tout le monde"
+    "contacts_historyCleared": "L'historique de conversation a été supprimé pour tout le monde",
+    "diagram_modesOptionLabel": "Changer le thème pour {0}, réactualise l'application",
+    "diagram_sketchTheme": "Croquis",
+    "diagram_simpleTheme": "Simple",
+    "diagram_classicTheme": "Classique"
 }

--- a/www/common/translations/messages.json
+++ b/www/common/translations/messages.json
@@ -1877,5 +1877,9 @@
     "contacts_muted": "Muted",
     "contacts_noFriends": "Your contact list is empty",
     "contacts_noFriendsInfo": "Start by <a>adding a contact</a> to begin a conversation.",
-    "contacts_historyCleared": "The chat history has been deleted for everyone"
+    "contacts_historyCleared": "The chat history has been deleted for everyone",
+    "diagram_modesOptionLabel": "Change theme to {0}, will refresh app",
+    "diagram_sketchTheme": "Sketch",
+    "diagram_simpleTheme": "Simple",
+    "diagram_classicTheme": "Classic"
 }


### PR DESCRIPTION
Translations update from [CryptPad Translations](https://weblate.cryptpad.org) for [CryptPad/App](https://weblate.cryptpad.org/projects/cryptpad/app/).



Current translation status:

![Weblate translation status](https://weblate.cryptpad.org/widget/cryptpad/app/horizontal-auto.svg)